### PR TITLE
[#17] Allow underscores in integers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ The change log is available [on GitHub][2].
 0.5.0
 =====
 
+* [#97](https://github.com/kowainik/tomland/pull/97)
+  Allow underscores in integers*.
 * [#96](https://github.com/kowainik/tomland/issues/96):
   Migrate to megaparsec 7.0
 * [#81](https://github.com/kowainik/tomland/issues/81):

--- a/test/Test/Toml/Parsing/Unit.hs
+++ b/test/Test/Toml/Parsing/Unit.hs
@@ -38,6 +38,7 @@ spec_Parser = do
         dateTimeFailOn  = failOn dateTimeP
         doubleFailOn    = failOn doubleP
         keyValFailOn    = failOn keyValP
+        integerFailOn   = failOn integerP
         textFailOn      = failOn textP
 
         doubleSatisfies = parseXSatisfies doubleP
@@ -161,15 +162,15 @@ spec_Parser = do
                 $ do
                       parseInteger "-9223372036854775808" (-9223372036854775808)
                       parseInteger "9223372036854775807"  9223372036854775807
-          --xit "can parse numbers with underscores between digits" $ do
-          --  parseInt "1_000" 1000
-          --  parseInt "5_349_221" 5349221
-          --  parseInt "1_2_3_4_5" 12345
-          --  parseInt "1_2_3_" 1
-          --  parseInt "13_" 13
-          --  intFailOn "_123_"
-          --  intFailOn "_13"
-          --  intFailOn "_"
+            it "can parse numbers with underscores between digits" $ do
+               parseInteger "1_000" 1000
+               parseInteger "5_349_221" 5349221
+               parseInteger "1_2_3_4_5" 12345
+               integerFailOn "1_2_3_"
+               integerFailOn "13_"
+               integerFailOn "_123_"
+               integerFailOn "_13"
+               integerFailOn "_"
           --xit "does not parse numbers with leading zeros" $ do
           --  parseInt "0123" 0
           --  parseInt "-023" 0


### PR DESCRIPTION
This PR aims to allow underscores in number as mentioned in #17. 

### Some facts about this implementation
- I've used existing commented out tests and assumed they contain the desired behaviour (the TOML spec doesn't cover some of the edge cases in the commented tests).
- This only works for integers.

### Some concerns about the implementation (any suggestions to improve work but appreciated):
- The removing of the underscores is done in a separate action from the parsing. I can use explicit parsers rather than the `match` function, but it's less concise.
- I'm not happy with the use of `undefined` in `fromRight` but the parser should ensure this never happens.

Resolves #17