### PR TITLE
[#64] Re-implemented `decimalP`

### DIFF
--- a/src/Toml/Parser.hs
+++ b/src/Toml/Parser.hs
@@ -28,7 +28,7 @@ import Data.Text (Text)
 import Data.Time (LocalTime (..), ZonedTime (..), fromGregorianValid, makeTimeOfDayValid,
                   minutesToTimeZone)
 import Data.Void (Void)
-import Text.Megaparsec (Parsec, anySingle, errorBundlePretty, match, satisfy, try, notFollowedBy)
+import Text.Megaparsec (Parsec, anySingle, errorBundlePretty, satisfy, try)
 import Text.Megaparsec.Char (alphaNumChar, char, digitChar, eol, hexDigitChar, space, space1,
                              string, tab)
 
@@ -44,7 +44,7 @@ import qualified Text.Megaparsec.Char.Lexer as L
 
 ----------------------------------------------------------------------------
 -- Library for parsing (boilerplate copy-pasted from megaparsec tutorial)
-----------------------------------------------------------------------------
+------------------------------------------------------ ----------------------
 
 type Parser = Parsec Void Text
 

--- a/src/Toml/Parser.hs
+++ b/src/Toml/Parser.hs
@@ -17,8 +17,9 @@ module Toml.Parser
 
 -- I hate default Prelude... Do I really need to import all this stuff manually?..
 import Control.Applicative (Alternative (..))
-import Control.Applicative.Combinators (between, count, manyTill, optional, sepEndBy, skipMany)
+import Control.Applicative.Combinators (between, count, manyTill, optional, sepEndBy, skipMany, some, sepBy1)
 import Control.Monad (void)
+--import Control.Monad.Fail (fail)
 import Data.Char (chr, isControl)
 import Data.Either (fromRight)
 import Data.Fixed (Pico)
@@ -27,7 +28,7 @@ import Data.Text (Text)
 import Data.Time (LocalTime (..), ZonedTime (..), fromGregorianValid, makeTimeOfDayValid,
                   minutesToTimeZone)
 import Data.Void (Void)
-import Text.Megaparsec (Parsec, anySingle, errorBundlePretty, match, satisfy, try)
+import Text.Megaparsec (Parsec, anySingle, errorBundlePretty, match, satisfy, try, notFollowedBy)
 import Text.Megaparsec.Char (alphaNumChar, char, digitChar, eol, hexDigitChar, space, space1,
                              string, tab)
 
@@ -160,15 +161,30 @@ tableNameP :: Parser Key
 tableNameP = lexeme $ between (char '[') (char ']') keyP
 
 -- Values
-
 decimalP :: Parser Integer
-decimalP = mkInteger <$> decimalStringP
+decimalP = matchInteger >>= validateInteger
   where
-    decimalStringP   = fst <$> match (some digitChar >> many _digitsP)
-    _digitsP         = try (char '_') >> some digitChar
-    mkInteger        = textToInt . stripUnderscores
-    textToInt        = fst . fromRight (error "Underscore parser has a bug") . TR.decimal
-    stripUnderscores = Text.filter (/= '_')
+    textToInt :: Text -> Integer
+    textToInt = fst . fromRight (error "Underscore parser has a bug") . TR.decimal
+
+    {-
+      Requires that `chars` be only digits 0-9. Returns a `Parser Integer` instead of an `Integer` to be easily changed if proper warning/error handling is implmented.
+    -}
+    validateInteger :: [Char] -> Parser Integer
+    validateInteger chars = case chars of
+      '0':[] -> pure 0
+      '0':_  -> fail "Can't parse a non-zero number starting with '0'"
+      _      -> pure . textToInt . Text.pack $ chars
+    
+    {-
+      Matches a list of characters if
+        * The first and last charactors are digits
+        * There are between 0 and 1 underscores between each character
+    -}
+    matchInteger :: Parser [Char]
+    matchInteger = sepBy1 digitChar (optional (char '_'))
+
+
 
 integerP :: Parser Integer
 integerP = lexeme $ binary <|> octal <|> hexadecimal <|> decimal

--- a/test/Test/Toml/Parsing/Unit.hs
+++ b/test/Test/Toml/Parsing/Unit.hs
@@ -171,9 +171,9 @@ spec_Parser = do
                integerFailOn "_123_"
                integerFailOn "_13"
                integerFailOn "_"
-          --xit "does not parse numbers with leading zeros" $ do
-          --  parseInt "0123" 0
-          --  parseInt "-023" 0
+            it "does not parse numbers with leading zeros" $ do
+              integerFailOn "0123"
+              integerFailOn "-023"
         context "when the integer is in binary representation" $ do
             it "can parse numbers prefixed with `0b`" $ do
                 parseInteger "0b1101" 13


### PR DESCRIPTION
Re-implemented `decimalP`, disallowing leading zeros and double underscores to be matched when parsing integers. This is a copy of my previous pull request but from the master branch.