### PR TITLE
[#22] Report proper type checking error during parsing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ The change log is available [on GitHub][2].
 0.5.0
 =====
 
+* [#22] (https://github.com/kowainik/tomland/issues/22)
+  Report proper type checking error during parsing
 * [#95](https://github.com/kowainik/tomland/issues/95)
   Swap fields in BiMaps for consistency with `lens` package.
 * [#70](https://github.com/kowainik/tomland/issues/70)


### PR DESCRIPTION
Resolves #22 

The problem is a consequence of typechecking after parsing, using the parser monad. When
the error was produced, as the parser had already consumed the input of the whole array,
the error position was set to the beggining of the next line. A trivial improvement would
be to typecheck before the lexeme parser, which consumes the newline. This way, the error
would be pointed to the end of the array, instead of the next line.

I've implemented a better improvement: to parse the array's elements using the parser that
succeeded to parse the first element. This way, typechecking is done as the array is being
parsed, and type errors are pointed to the exact mismatching element.

A better solution would be to split the parsing and typechecking in two phases. The parser
would preserve the token position in a custom datatype, and the typechecker would use that
data to inform the position of the type mismatch. This would require a major rewrite of the parser and type modules.