### PR TITLE
[#64] No leading zeros

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,12 +10,14 @@ The change log is available [on GitHub][2].
 
   _Migration guide:_ change `Toml.wrapper Toml.text "foo"` to `Toml.diwrap (Toml.text "foo")`.
 * [#131](https://github.com/kowainik/tomland/issues/131):
-  Uncommenting `tomlTableArrays` from 'TOML'.
+  Uncommenting `tomlTableArrays` from `TOML`.
+* [#64](https://github.com/kowainik/tomland/issues/64):
+  Integer parser doesn't accept leading zeros.
 * [#142](https://github.com/kowainik/tomland/issues/142):
   Adding EDSL support for arrays of tables
 * [#149](https://github.com/kowainik/tomland/issues/149):
   Removing records syntax from `PrefixTree`.
-  
+
 ## 0.5.0 — Nov 12, 2018
 
 * [#81](https://github.com/kowainik/tomland/issues/81):

--- a/benchmark/Benchmark/Tomland.hs
+++ b/benchmark/Benchmark/Tomland.hs
@@ -21,6 +21,7 @@ codec = HaskellType
     <*> Toml.arrayOf Toml._Text "words" .= htWords
     <*> Toml.arrayOf Toml._Bool "bool" .= htBool
     <*> Toml.zonedTime "today" .= htToday
+    <*> Toml.arrayOf Toml._Integer "ints" .= htInt
     <*> Toml.table insideF "fruit" .= htFruit
     <*> Toml.table insideS "size" .= htSize
 

--- a/benchmark/Benchmark/Tomland.hs
+++ b/benchmark/Benchmark/Tomland.hs
@@ -21,7 +21,7 @@ codec = HaskellType
     <*> Toml.arrayOf Toml._Text "words" .= htWords
     <*> Toml.arrayOf Toml._Bool "bool" .= htBool
     <*> Toml.zonedTime "today" .= htToday
-    <*> Toml.arrayOf Toml._Integer "ints" .= htInt
+    <*> Toml.arrayOf Toml._Integer "ints" .= htInteger
     <*> Toml.table insideF "fruit" .= htFruit
     <*> Toml.table insideS "size" .= htSize
 

--- a/benchmark/Benchmark/Type.hs
+++ b/benchmark/Benchmark/Type.hs
@@ -16,15 +16,15 @@ import GHC.Generics (Generic)
 
 -- | Haskell type to convert to.
 data HaskellType = HaskellType
-    { htTitle :: Text
-    , htAtom  :: Double
-    , htCash  :: Bool
-    , htWords :: [Text]
-    , htBool  :: [Bool]
-    , htToday :: ZonedTime
-    , htInt  :: [Int]
-    , htFruit :: FruitInside
-    , htSize  :: SizeInside
+    { htTitle   :: Text
+    , htAtom    :: Double
+    , htCash    :: Bool
+    , htWords   :: [Text]
+    , htBool    :: [Bool]
+    , htToday   :: ZonedTime
+    , htInteger :: [Integer]
+    , htFruit   :: FruitInside
+    , htSize    :: SizeInside
     } deriving (Show, NFData, Generic)
 
 instance FromJSON HaskellType where

--- a/benchmark/Benchmark/Type.hs
+++ b/benchmark/Benchmark/Type.hs
@@ -22,6 +22,7 @@ data HaskellType = HaskellType
     , htWords :: [Text]
     , htBool  :: [Bool]
     , htToday :: ZonedTime
+    , htInt  :: [Int]
     , htFruit :: FruitInside
     , htSize  :: SizeInside
     } deriving (Show, NFData, Generic)
@@ -34,6 +35,7 @@ instance FromJSON HaskellType where
         <*> o .: "words"
         <*> o .: "bool"
         <*> o .: "today"
+        <*> o .: "ints"
         <*> o .: "fruit"
         <*> o .: "size"
 

--- a/benchmark/benchmark.toml
+++ b/benchmark/benchmark.toml
@@ -6,6 +6,7 @@ cash = true
 words = [ "all", 'strings', """are the same""", '''type''']
 bool = [false, true, false]
 today = 1979-05-27T07:32:00Z  # ZonedTime
+ints = [0, 1, 2, 120, 9000, -5, +12, -100]
 # digits = [1.0, 2.0, nan, -nan, +inf, -inf, 1.0]  # not for TOML v0.4.0
 # date = [1895-05-27, 1980-11-23, 2018-10-25]  # [Day] not for TOML v0.4.0
 

--- a/src/Toml/Parser/Core.hs
+++ b/src/Toml/Parser/Core.hs
@@ -17,7 +17,7 @@ import Text.Megaparsec (Parsec, anySingle, errorBundlePretty, match, parse, sati
 import Text.Megaparsec.Char (alphaNumChar, char, digitChar, eol, hexDigitChar, space, space1,
                              string, tab)
 import Text.Megaparsec.Char.Lexer (binary, float, hexadecimal, octal, signed, skipLineComment,
-                                   symbol)
+                                   symbol, decimal)
 import qualified Text.Megaparsec.Char.Lexer as L (lexeme, space)
 
 

--- a/src/Toml/Parser/Core.hs
+++ b/src/Toml/Parser/Core.hs
@@ -13,7 +13,7 @@ import Control.Applicative (Alternative (empty))
 import Data.Text (Text)
 import Data.Void (Void)
 
-import Text.Megaparsec (Parsec, anySingle, errorBundlePretty, match, parse, satisfy, try, (<?>))
+import Text.Megaparsec (Parsec, anySingle, errorBundlePretty, match, parse, satisfy, try, (<?>), eof)
 import Text.Megaparsec.Char (alphaNumChar, char, digitChar, eol, hexDigitChar, space, space1,
                              string, tab)
 import Text.Megaparsec.Char.Lexer (binary, float, hexadecimal, octal, signed, skipLineComment,

--- a/src/Toml/Parser/Core.hs
+++ b/src/Toml/Parser/Core.hs
@@ -13,7 +13,8 @@ import Control.Applicative (Alternative (empty))
 import Data.Text (Text)
 import Data.Void (Void)
 
-import Text.Megaparsec (Parsec, anySingle, errorBundlePretty, match, parse, satisfy, try, (<?>), eof)
+import Text.Megaparsec (Parsec, anySingle, errorBundlePretty, match, parse,
+                        satisfy, try, (<?>), eof, oneOf, lookAhead)
 import Text.Megaparsec.Char (alphaNumChar, char, digitChar, eol, hexDigitChar, space, space1,
                              string, tab)
 import Text.Megaparsec.Char.Lexer (binary, float, hexadecimal, octal, signed, skipLineComment,

--- a/src/Toml/Parser/Core.hs
+++ b/src/Toml/Parser/Core.hs
@@ -13,12 +13,10 @@ import Control.Applicative (Alternative (empty))
 import Data.Text (Text)
 import Data.Void (Void)
 
-import Text.Megaparsec (Parsec, anySingle, errorBundlePretty, match, parse,
-                        satisfy, try, (<?>), eof, oneOf, lookAhead)
+import Text.Megaparsec (Parsec, anySingle, errorBundlePretty, match, parse, satisfy, try, (<?>))
 import Text.Megaparsec.Char (alphaNumChar, char, digitChar, eol, hexDigitChar, space, space1,
                              string, tab)
-import Text.Megaparsec.Char.Lexer (binary, float, hexadecimal, octal, signed, skipLineComment,
-                                   symbol, decimal)
+import Text.Megaparsec.Char.Lexer (binary, float, hexadecimal, octal, signed, skipLineComment, symbol)
 import qualified Text.Megaparsec.Char.Lexer as L (lexeme, space)
 
 

--- a/src/Toml/Parser/Value.hs
+++ b/src/Toml/Parser/Value.hs
@@ -25,7 +25,7 @@ import Data.Time (LocalTime (..), ZonedTime (..), fromGregorianValid, makeTimeOf
 
 import Toml.Parser.Core (Parser, alphaNumChar, anySingle, binary, char, digitChar, eol, float,
                          hexDigitChar, hexadecimal, lexeme, octal, satisfy, sc, signed,
-                         space, string, tab, text, try, (<?>))
+                         space, string, tab, text, try, (<?>), space1, eof)
 import Toml.PrefixTree (Key (..), Piece (..))
 import Toml.Type (DateTime (..), UValue (..), AnyValue, typeCheck)
 
@@ -146,7 +146,10 @@ tableNameP = between (text "[") (text "]") keyP
 -- Values
 
 decimalP :: Parser Integer
-decimalP = fst . head . readDec . concat <$> sepBy1 (some digitChar) (char '_')
+decimalP = zero <|> more
+  where
+    zero = 0 <$ char '0' <* (space1 <|> eof)
+    more = fst . head . readDec . concat <$> sepBy1 (some digitChar) (char '_')
 
 integerP :: Parser Integer
 integerP = lexeme (bin <|> oct <|> hex <|> dec) <?> "integer"

--- a/src/Toml/Parser/Value.hs
+++ b/src/Toml/Parser/Value.hs
@@ -16,6 +16,7 @@ import Control.Applicative.Combinators (between, count, manyTill, option, option
                                         skipMany, sepBy1)
 
 import Data.Char (chr, isControl)
+import Text.Read (readMaybe)
 import Data.Fixed (Pico)
 import Data.Semigroup ((<>))
 import Data.Text (Text)
@@ -147,8 +148,9 @@ tableNameP = between (text "[") (text "]") keyP
 decimalP :: Parser Integer
 decimalP = zero <|> more
   where
-    zero = signed sc (0 <$ char '0')
-    more = read . concat <$> sepBy1 (some digitChar) (char '_')
+    zero = 0 <$ char '0'
+    more = check =<< readMaybe . concat <$> sepBy1 (some digitChar) (char '_')
+    check = maybe (fail "Not an integer") return
 
 
 integerP :: Parser Integer

--- a/src/Toml/Parser/Value.hs
+++ b/src/Toml/Parser/Value.hs
@@ -149,7 +149,8 @@ decimalP :: Parser Integer
 decimalP = zero <|> more
   where
     zero = 0 <$ char '0'
-    more = fst . head . readDec . concat <$> sepBy1 (some digitChar) (char '_')
+    more = stringToInt <$> sepBy1 (some digitChar) (char '_')
+    stringToInt = fst . head . readDec . concat
 
 integerP :: Parser Integer
 integerP = lexeme ((bin <|> oct <|> hex <|> dec) <* lookAhead sep) <?> "integer"

--- a/src/Toml/Parser/Value.hs
+++ b/src/Toml/Parser/Value.hs
@@ -12,22 +12,22 @@ module Toml.Parser.Value
        ) where
 
 import Control.Applicative (Alternative (some, (<|>)))
-import Control.Applicative.Combinators (between, count, manyTill, option, optional, sepEndBy,
-                                        skipMany, sepBy1)
+import Control.Applicative.Combinators (between, count, manyTill, option, optional, sepBy1,
+                                        sepEndBy, skipMany)
 
 import Data.Char (chr, isControl)
-import Text.Read (readMaybe)
 import Data.Fixed (Pico)
 import Data.Semigroup ((<>))
 import Data.Text (Text)
 import Data.Time (LocalTime (..), ZonedTime (..), fromGregorianValid, makeTimeOfDayValid,
                   minutesToTimeZone)
+import Text.Read (readMaybe)
 
 import Toml.Parser.Core (Parser, alphaNumChar, anySingle, binary, char, digitChar, eol, float,
-                         hexDigitChar, hexadecimal, lexeme, octal, satisfy, sc, signed,
-                         space, string, tab, text, try, (<?>))
+                         hexDigitChar, hexadecimal, lexeme, octal, satisfy, sc, signed, space,
+                         string, tab, text, try, (<?>))
 import Toml.PrefixTree (Key (..), Piece (..))
-import Toml.Type (DateTime (..), UValue (..), AnyValue, typeCheck)
+import Toml.Type (AnyValue, DateTime (..), UValue (..), typeCheck)
 
 import qualified Control.Applicative.Combinators.NonEmpty as NC
 import qualified Data.Text as Text
@@ -275,13 +275,12 @@ arrayP = lexeme (between (char '[' *> sc) (char ']') elements) <?> "array"
 
 
 valueP :: Parser UValue
-valueP = UBool    <$> boolP
+valueP = UText    <$> textP
+     <|> UBool    <$> boolP
+     <|> UArray   <$> arrayP
      <|> UDate    <$> dateTimeP
      <|> UDouble  <$> try doubleP
      <|> UInteger <$> integerP
-     <|> UText    <$> textP
-     <|> UArray   <$> arrayP
-
 
 anyValueP :: Parser AnyValue
 anyValueP = typeCheck <$> valueP >>= \case

--- a/test/Test/Toml/Parsing/Unit.hs
+++ b/test/Test/Toml/Parsing/Unit.hs
@@ -171,45 +171,45 @@ spec_Parser = do
                integerFailOn "_123_"
                integerFailOn "_13"
                integerFailOn "_"
-          --xit "does not parse numbers with leading zeros" $ do
-          --  parseInt "0123" 0
-          --  parseInt "-023" 0
+            it "does not parse numbers with leading zeros" $ do
+               integerFailOn "0123"
+               integerFailOn "-023"
         context "when the integer is in binary representation" $ do
             it "can parse numbers prefixed with `0b`" $ do
                 parseInteger "0b1101" 13
                 parseInteger "0b0"    0
             it "does not parse numbers prefixed with `0B`"
-                $ parseInteger "0B1101" 0
+                $ integerFailOn "0B1101"
             it "can parse numbers with leading zeros after the prefix" $ do
                 parseInteger "0b000"   0
                 parseInteger "0b00011" 3
-            it "does not parse negative numbers" $ parseInteger "-0b101" 0
+            it "does not parse negative numbers" $ integerFailOn "-0b101"
             it "does not parse numbers with non-valid binary digits"
-                $ parseInteger "0b123" 1
+                $ integerFailOn "0b123"
         context "when the integer is in octal representation" $ do
             it "can parse numbers prefixed with `0o`" $ do
                 parseInteger "0o567" 0o567
                 parseInteger "0o0"   0
             it "does not parse numbers prefixed with `0O`"
-                $ parseInteger "0O567" 0
+                $ integerFailOn "0O567"
             it "can parse numbers with leading zeros after the prefix" $ do
                 parseInteger "0o000000" 0
                 parseInteger "0o000567" 0o567
-            it "does not parse negative numbers" $ parseInteger "-0o123" 0
+            it "does not parse negative numbers" $ integerFailOn "-0o123"
             it "does not parse numbers with non-valid octal digits"
-                $ parseInteger "0o789" 0o7
+                $ integerFailOn "0o789"
         context "when the integer is in hexadecimal representation" $ do
             it "can parse numbers prefixed with `0x`" $ do
                 parseInteger "0x12af" 0x12af
                 parseInteger "0x0"    0
             it "does not parse numbers prefixed with `0X`"
-                $ parseInteger "0Xfff" 0
+                $ integerFailOn "0Xfff"
             it "can parse numbers with leading zeros after the prefix" $ do
                 parseInteger "0x00000" 0
                 parseInteger "0x012af" 0x12af
-            it "does not parse negative numbers" $ parseInteger "-0xfff" 0
+            it "does not parse negative numbers" $ integerFailOn "-0xfff"
             it "does not parse numbers with non-valid hexadecimal digits"
-                $ parseInteger "0xfgh" 0xf
+                $ integerFailOn "0xfgh"
             it "can parse numbers when hex digits are lowercase"
                 $ parseInteger "0xabcdef" 0xabcdef
             it "can parse numbers when hex digits are uppercase"

--- a/test/Test/Toml/Parsing/Unit.hs
+++ b/test/Test/Toml/Parsing/Unit.hs
@@ -157,11 +157,9 @@ spec_Parser = do
             it "can parse sign-prefixed zero as an unprefixed zero" $ do
                 parseInteger "+0" 0
                 parseInteger "-0" 0
-            it
-                    "can parse both the minimum and maximum numbers in the 64 bit range"
-                $ do
-                      parseInteger "-9223372036854775808" (-9223372036854775808)
-                      parseInteger "9223372036854775807"  9223372036854775807
+            it "can parse both the minimum and maximum numbers in the 64 bit range"
+                $ do parseInteger "-9223372036854775808" (-9223372036854775808)
+                     parseInteger "9223372036854775807"  9223372036854775807
             it "can parse numbers with underscores between digits" $ do
                parseInteger "1_000" 1000
                parseInteger "5_349_221" 5349221
@@ -172,44 +170,44 @@ spec_Parser = do
                integerFailOn "_13"
                integerFailOn "_"
             it "does not parse numbers with leading zeros" $ do
-               integerFailOn "0123"
-               integerFailOn "-023"
+               parseInteger "0123" 0
+               parseInteger "-023" 0
         context "when the integer is in binary representation" $ do
             it "can parse numbers prefixed with `0b`" $ do
                 parseInteger "0b1101" 13
                 parseInteger "0b0"    0
             it "does not parse numbers prefixed with `0B`"
-                $ integerFailOn "0B1101"
+                $ parseInteger "0B1101" 0
             it "can parse numbers with leading zeros after the prefix" $ do
                 parseInteger "0b000"   0
                 parseInteger "0b00011" 3
-            it "does not parse negative numbers" $ integerFailOn "-0b101"
+            it "does not parse negative numbers" $ parseInteger "-0b101" 0
             it "does not parse numbers with non-valid binary digits"
-                $ integerFailOn "0b123"
+                $ parseInteger "0b123" 1
         context "when the integer is in octal representation" $ do
             it "can parse numbers prefixed with `0o`" $ do
                 parseInteger "0o567" 0o567
                 parseInteger "0o0"   0
             it "does not parse numbers prefixed with `0O`"
-                $ integerFailOn "0O567"
+                $ parseInteger "0O567" 0
             it "can parse numbers with leading zeros after the prefix" $ do
                 parseInteger "0o000000" 0
                 parseInteger "0o000567" 0o567
-            it "does not parse negative numbers" $ integerFailOn "-0o123"
+            it "does not parse negative numbers" $ parseInteger "-0o123" 0
             it "does not parse numbers with non-valid octal digits"
-                $ integerFailOn "0o789"
+                $ parseInteger "0o789" 0o7
         context "when the integer is in hexadecimal representation" $ do
             it "can parse numbers prefixed with `0x`" $ do
                 parseInteger "0x12af" 0x12af
                 parseInteger "0x0"    0
             it "does not parse numbers prefixed with `0X`"
-                $ integerFailOn "0Xfff"
+                $ parseInteger "0Xfff" 0
             it "can parse numbers with leading zeros after the prefix" $ do
                 parseInteger "0x00000" 0
                 parseInteger "0x012af" 0x12af
-            it "does not parse negative numbers" $ integerFailOn "-0xfff"
+            it "does not parse negative numbers" $ parseInteger "-0xfff" 0
             it "does not parse numbers with non-valid hexadecimal digits"
-                $ integerFailOn "0xfgh"
+                $ parseInteger "0xfgh" 0xf
             it "can parse numbers when hex digits are lowercase"
                 $ parseInteger "0xabcdef" 0xabcdef
             it "can parse numbers when hex digits are uppercase"


### PR DESCRIPTION
Addressing #64 

I re-implemented `decimalP`, it's much simpler now. 
I've uncommented the test on leading zeroes, and modified the `does not parse numbers` tests to actually test failure and not success. To make those pass I had to use the `lookAhead` trick.

While testing these, I realized that the string `"a = 123.3b=23"` is accepted and parsed like `"a = 123.3\nb=23"`. Same for `"a = trueb=23"` and others. It's kind of a weird case, I don't know if it's worth spending time on. Note: `"a = 123b=23"` does not parse because I've used the `lookAhead` trick for integers, so it's definitely fixable.