### PR TITLE
[#131] Uncommenting tomlTableArrays

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ The change log is available [on GitHub][2].
 0.5.0
 =====
 
+* [#131](https://github.com/kowainik/tomland/issues/131):
+  Uncommenting `tomlTableArrays` from 'TOML'.
 * [#115](https://github.com/kowainik/tomland/issues/115):
   Added time combinators to `Toml.BiMap` and `Toml.Bi.Combinators`.
 * [#99](https://github.com/kowainik/tomland/issues/99):

--- a/src/Toml/Bi/Combinators.hs
+++ b/src/Toml/Bi/Combinators.hs
@@ -183,7 +183,7 @@ arrayOf bimap key = Codec input output
     output :: [a] -> St [a]
     output a = do
         anyVal <- MaybeT $ pure $ forward (_Array bimap) a
-        a <$ modify (\(TOML vals tables) -> TOML (HashMap.insert key anyVal vals) tables)
+        a <$ modify (\(TOML vals tables arrays) -> TOML (HashMap.insert key anyVal vals) tables arrays)
 
 -- | Parser for tables. Use it when when you have nested objects.
 table :: forall a . TomlCodec a -> Key -> TomlCodec a

--- a/src/Toml/Parser/TOML.hs
+++ b/src/Toml/Parser/TOML.hs
@@ -33,7 +33,7 @@ distributeEithers = foldr distribute ([], [])
     distribute (k, Right b) (ls, rs) = (ls, (k, b) : rs)
 
 makeToml :: [(Key, Either AnyValue TOML)] -> TOML
-makeToml kvs = TOML (HashMap.fromList lefts) (fromList rights)
+makeToml kvs = TOML (HashMap.fromList lefts) (fromList rights) mempty
   where
     (lefts, rights) = distributeEithers kvs
 
@@ -44,4 +44,5 @@ tomlP = do
     tables <- many tableHeaderP
     return TOML { tomlPairs  = HashMap.fromList val
                 , tomlTables = fromList $ tables ++ inline
+                , tomlTableArrays = mempty
                 }

--- a/test/Test/Toml/Gen.hs
+++ b/test/Test/Toml/Gen.hs
@@ -110,13 +110,13 @@ genTableHeader = do
     pure (k, toml)
   where
     makeToml :: [(Key, AnyValue)] -> TOML
-    makeToml kv = TOML (HashMap.fromList kv) mempty
+    makeToml kv = TOML (HashMap.fromList kv) mempty mempty
 
 genToml :: MonadGen m => m TOML
 genToml = do
     kv     <- HashMap.fromList <$> genKeyAnyValueList
     tables <- Gen.list (Range.linear 0 10) genTableHeader
-    pure $ TOML kv (fromList tables)
+    pure $ TOML kv (fromList tables) mempty
 
 genDay :: MonadGen m => m Day
 genDay = do

--- a/test/Test/Toml/Parsing/Unit.hs
+++ b/test/Test/Toml/Parsing/Unit.hs
@@ -58,7 +58,7 @@ spec_Parser = do
 
         makeKey k = (Key . NE.fromList) (map Piece k)
 
-        tomlFromList kv = TOML (HashMap.fromList kv) mempty
+        tomlFromList kv = TOML (HashMap.fromList kv) mempty mempty
 
 
     describe "arrayP" $ do
@@ -522,4 +522,4 @@ spec_Parser = do
             tomlTables = fromList
                 [(makeKey ["owner"], tomlFromList [nameKV, enabledKV])]
 
-        parseToml tomlString (TOML tomlPairs tomlTables)
+        parseToml tomlString (TOML tomlPairs tomlTables mempty)


### PR DESCRIPTION
As title says.
I used `mempty` wherever `tomlTableArrays` was required.
All tests pass.