### PR TITLE
[#130] Added combinators

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ The change log is available [on GitHub][2].
 0.5.0
 =====
 
+* [#130](https://github.com/kowainik/tomland/issues/130):
+  Added combinators to `Toml.Bi.Combinators`.
 * [#115](https://github.com/kowainik/tomland/issues/115):
   Added time combinators to `Toml.BiMap` and `Toml.Bi.Combinators`.
 * [#99](https://github.com/kowainik/tomland/issues/99):

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,7 +18,7 @@ The change log is available [on GitHub][2].
 * [#95](https://github.com/kowainik/tomland/issues/95):
   Swap fields in BiMaps for consistency with `lens` package.
 * [#70](https://github.com/kowainik/tomland/issues/70):
-  Add `_TextBy` and `_Show` combinators.
+  Add `_TextBy` and `_Read` combinators.
 * [#11](https://github.com/kowainik/tomland/issues/11):
   Add `PrintOptions` (sorting, indentation) for pretty printer.
 * [#17](https://github.com/kowainik/tomland/issues/17):

--- a/src/Toml/Bi/Combinators.hs
+++ b/src/Toml/Bi/Combinators.hs
@@ -59,7 +59,7 @@ import Toml.Bi.Code (DecodeException (..), Env, St, TomlCodec)
 import Toml.Bi.Monad (Codec (..), dimap)
 import Toml.BiMap (BiMap (..), _Array, _Bool, _Double,
                    _Integer, _String, _Text, _ZonedTime, _LocalTime, _Day,
-                   _TimeOfDay, _Int, _Word, _Natural, _Float, _Show,
+                   _TimeOfDay, _Int, _Word, _Natural, _Float, _Read,
                    _ByteString, _LByteString, _Set, _IntSet, _HashSet,
                    _NonEmpty)
 import Toml.Parser (ParseException (..))
@@ -152,62 +152,80 @@ integer = match _Integer
 int :: Key -> TomlCodec Int
 int = match _Int
 
+-- | Parser for natural values.
 natural :: Key -> TomlCodec Natural
 natural = match _Natural
 
+-- | Parser for word values.
 word :: Key -> TomlCodec Word
 word = match _Word
 
--- | Parser for floating values.
+-- | Parser for floating point values as double.
 double :: Key -> TomlCodec Double
 double = match _Double
 
+-- | Parser for floating point values as float.
 float :: Key -> TomlCodec Float
 float = match _Float
 
--- | Parser for string values.
+-- | Parser for string values as text.
 text :: Key -> TomlCodec Text
 text = match _Text
 
--- | Codec for 'String'.
+-- | Parser for string values as string.
 string :: Key -> TomlCodec String
 string = match _String
 
+-- | Parser for values with a `Read` and `Show` instance.
 read :: (Show a, Read a, Typeable a) => Key -> TomlCodec a
-read = match _Show
+read = match _Read
 
+-- | Parser for byte vectors values as strict bytestring.
 byteString :: Key -> TomlCodec ByteString
 byteString = match _ByteString
 
+-- | Parser for byte vectors values as lazy bytestring.
 lbyteString :: Key -> TomlCodec BL.ByteString
 lbyteString = match _LByteString
 
+-- | Parser for zoned time values.
 zonedTime :: Key -> TomlCodec ZonedTime
 zonedTime = match _ZonedTime
 
+-- | Parser for local time values.
 localTime :: Key -> TomlCodec LocalTime
 localTime = match _LocalTime
 
+-- | Parser for day values.
 day :: Key -> TomlCodec Day
 day = match _Day
 
+-- | Parser for time of day values.
 timeOfDay :: Key -> TomlCodec TimeOfDay
 timeOfDay = match _TimeOfDay
 
--- | Parser for list of values. Takes converter for single array element and
--- returns list of values.
+-- | Parser for list of values. Takes converter for single value and
+-- returns a list of values.
 arrayOf :: Typeable a => BiMap a AnyValue -> Key -> TomlCodec [a]
 arrayOf = match . _Array
 
+-- | Parser for sets. Takes converter for single value and
+-- returns a set of values.
 arraySetOf :: (Typeable a, Ord a) => BiMap a AnyValue -> Key -> TomlCodec (Set a)
 arraySetOf = match . _Set
 
+-- | Parser for sets of ints. Takes converter for single value and
+-- returns a set of ints.
 arrayIntSet :: Key -> TomlCodec IntSet
 arrayIntSet = match _IntSet
 
+-- | Parser for hash sets. Takes converter for single hashable value and
+-- returns a set of hashable values.
 arrayHashSetOf :: (Typeable a, Hashable a, Eq a) => BiMap a AnyValue -> Key -> TomlCodec (HashSet a)
 arrayHashSetOf = match . _HashSet
 
+-- | Parser for non- empty lists of values. Takes converter for single value and
+-- returns a non-empty list of values.
 arrayNonEmptyOf :: Typeable a => BiMap a AnyValue -> Key -> TomlCodec (NonEmpty a)
 arrayNonEmptyOf = match . _NonEmpty
 

--- a/src/Toml/Bi/Combinators.hs
+++ b/src/Toml/Bi/Combinators.hs
@@ -17,7 +17,7 @@ module Toml.Bi.Combinators
        , read
        , string
        , byteString
-       , lbyteString
+       , lazyByteString
        , zonedTime
        , localTime
        , day
@@ -185,8 +185,8 @@ byteString :: Key -> TomlCodec ByteString
 byteString = match _ByteString
 
 -- | Parser for byte vectors values as lazy bytestring.
-lbyteString :: Key -> TomlCodec BL.ByteString
-lbyteString = match _LByteString
+lazyByteString :: Key -> TomlCodec BL.ByteString
+lazyByteString = match _LByteString
 
 -- | Parser for zoned time values.
 zonedTime :: Key -> TomlCodec ZonedTime

--- a/src/Toml/Bi/Combinators.hs
+++ b/src/Toml/Bi/Combinators.hs
@@ -14,19 +14,19 @@ module Toml.Bi.Combinators
        , double
        , float
        , text
-       , codecShow
+       , read
        , string
-       , bytestring
-       , lBytestring
+       , byteString
+       , lbyteString
        , zonedTime
        , localTime
        , day
        , timeOfDay
        , arrayOf
-       , setOf
-       , intSet
-       , hashSetOf
-       , nonEmptyOf
+       , arraySetOf
+       , arrayIntSet
+       , arrayHashSetOf
+       , arrayNonEmptyOf
 
          -- * Combinators
        , match
@@ -56,7 +56,7 @@ import Data.IntSet (IntSet)
 import Data.List.NonEmpty (NonEmpty)
 
 import Toml.Bi.Code (DecodeException (..), Env, St, TomlCodec)
-import Toml.Bi.Monad (BiCodec, Codec (..), dimap)
+import Toml.Bi.Monad (Codec (..), dimap)
 import Toml.BiMap (BiMap (..), _Array, _Bool, _Double,
                    _Integer, _String, _Text, _ZonedTime, _LocalTime, _Day,
                    _TimeOfDay, _Int, _Word, _Natural, _Float, _Show,
@@ -65,6 +65,8 @@ import Toml.BiMap (BiMap (..), _Array, _Bool, _Double,
 import Toml.Parser (ParseException (..))
 import Toml.PrefixTree (Key)
 import Toml.Type (AnyValue (..), TOML (..), insertKeyAnyVal, insertTable, valueType)
+
+import Prelude hiding (read)
 
 import qualified Data.HashMap.Strict as HashMap
 import qualified Data.Text as Text
@@ -171,14 +173,14 @@ text = match _Text
 string :: Key -> TomlCodec String
 string = match _String
 
-codecShow :: (Show a, Read a, Typeable a) => Key -> TomlCodec a
-codecShow = match _Show
+read :: (Show a, Read a, Typeable a) => Key -> TomlCodec a
+read = match _Show
 
-bytestring :: Key -> TomlCodec ByteString
-bytestring = match _ByteString
+byteString :: Key -> TomlCodec ByteString
+byteString = match _ByteString
 
-lBytestring :: Key -> TomlCodec BL.ByteString
-lBytestring = match _LByteString
+lbyteString :: Key -> TomlCodec BL.ByteString
+lbyteString = match _LByteString
 
 zonedTime :: Key -> TomlCodec ZonedTime
 zonedTime = match _ZonedTime
@@ -195,19 +197,19 @@ timeOfDay = match _TimeOfDay
 -- | Parser for list of values. Takes converter for single array element and
 -- returns list of values.
 arrayOf :: Typeable a => BiMap a AnyValue -> Key -> TomlCodec [a]
-arrayOf bimap = match (_Array bimap)
+arrayOf = match . _Array
 
-setOf :: (Typeable a, Ord a) => BiMap a AnyValue -> Key -> TomlCodec (Set a)
-setOf bimap = match (_Set bimap)
+arraySetOf :: (Typeable a, Ord a) => BiMap a AnyValue -> Key -> TomlCodec (Set a)
+arraySetOf = match . _Set
 
-intSet :: Key -> TomlCodec IntSet
-intSet = match _IntSet
+arrayIntSet :: Key -> TomlCodec IntSet
+arrayIntSet = match _IntSet
 
-hashSetOf :: (Typeable a, Hashable a, Eq a) => BiMap a AnyValue -> Key -> TomlCodec (HashSet a)
-hashSetOf bimap = match (_HashSet bimap)
+arrayHashSetOf :: (Typeable a, Hashable a, Eq a) => BiMap a AnyValue -> Key -> TomlCodec (HashSet a)
+arrayHashSetOf = match . _HashSet
 
-nonEmptyOf :: Typeable a => BiMap a AnyValue -> Key -> TomlCodec (NonEmpty a)
-nonEmptyOf bimap = match (_NonEmpty bimap)
+arrayNonEmptyOf :: Typeable a => BiMap a AnyValue -> Key -> TomlCodec (NonEmpty a)
+arrayNonEmptyOf = match . _NonEmpty
 
 -- | Parser for tables. Use it when when you have nested objects.
 table :: forall a . TomlCodec a -> Key -> TomlCodec a

--- a/src/Toml/Bi/Combinators.hs
+++ b/src/Toml/Bi/Combinators.hs
@@ -32,7 +32,6 @@ module Toml.Bi.Combinators
        , match
        , table
        , wrapper
-       , dimapNum
        , mdimap
        ) where
 
@@ -97,13 +96,6 @@ match BiMap{..} key = Codec input output
     output a = do
         anyVal <- MaybeT $ pure $ forward a
         a <$ modify (insertKeyAnyVal key anyVal)
-
--- | Helper dimapper to turn 'integer' parser into parser for 'Int', 'Natural', 'Word', etc.
-dimapNum
-    :: forall n r w . (Integral n, Functor r, Functor w)
-    => BiCodec r w Integer
-    -> BiCodec r w n
-dimapNum = dimap toInteger fromIntegral
 
 {- | Almost same as 'dimap'. Useful when you want to have fields like this
 inside your configuration:

--- a/src/Toml/BiMap.hs
+++ b/src/Toml/BiMap.hs
@@ -13,9 +13,14 @@ module Toml.BiMap
        , prism
 
          -- * Helpers for BiMap and AnyValue
-       , matchValueBackward
        , mkAnyValueBiMap
        , _TextBy
+       , _NaturalInteger
+       , _StringText
+       , _ShowString
+       , _BoundedInteger
+       , _ByteStringText
+       , _LByteStringText
 
          -- * Some predefined bi mappings
        , _Array
@@ -27,19 +32,13 @@ module Toml.BiMap
        , _LocalTime
        , _Day
        , _TimeOfDay
-       , _StringText
        , _String
-       , _ShowString
        , _Show
-       , _NaturalInteger
        , _Natural
-       , _BoundedInteger
        , _Word
        , _Int
        , _Float
-       , _ByteStringText
        , _ByteString
-       , _LByteStringText
        , _LByteString
        , _Set
        , _IntSet
@@ -66,7 +65,7 @@ import Text.Read (readMaybe)
 import Data.Time (Day, LocalTime, TimeOfDay, ZonedTime)
 
 import Toml.Type (AnyValue (..), TValue (TArray), Value (..), DateTime (..) ,
-                  liftMatch, matchArray, matchBool, matchDouble, matchInteger,
+                  matchArray, matchBool, matchDouble, matchInteger,
                   matchText, matchDate, reifyAnyValues)
 
 import qualified Control.Category as Cat
@@ -139,10 +138,6 @@ mkAnyValueBiMap :: (forall t . Value t -> Maybe a)
                 -> BiMap a AnyValue
 mkAnyValueBiMap matchValue toValue =
     BiMap (Just . AnyValue . toValue) (\(AnyValue value) -> matchValue value)
-
--- | Allows to match against given 'Value' using provided prism for 'AnyValue'.
-matchValueBackward :: BiMap a AnyValue -> Value t -> Maybe a
-matchValueBackward = liftMatch . backward
 
 -- | Creates prism for 'Text' to 'AnyValue' with custom functions
 _TextBy :: (a -> Text) -> (Text -> Maybe a) -> BiMap a AnyValue

--- a/src/Toml/BiMap.hs
+++ b/src/Toml/BiMap.hs
@@ -64,9 +64,9 @@ import Data.Hashable (Hashable)
 import Text.Read (readMaybe)
 import Data.Time (Day, LocalTime, TimeOfDay, ZonedTime)
 
-import Toml.Type (AnyValue (..), TValue (TArray), Value (..), DateTime (..) ,
+import Toml.Type (AnyValue (..), Value (..), DateTime (..) ,
                   matchArray, matchBool, matchDouble, matchInteger,
-                  matchText, matchDate, reifyAnyValues, toMArray)
+                  matchText, matchDate, toMArray)
 
 import qualified Control.Category as Cat
 import qualified Data.Text as T

--- a/src/Toml/BiMap.hs
+++ b/src/Toml/BiMap.hs
@@ -66,7 +66,7 @@ import Data.Time (Day, LocalTime, TimeOfDay, ZonedTime)
 
 import Toml.Type (AnyValue (..), TValue (TArray), Value (..), DateTime (..) ,
                   matchArray, matchBool, matchDouble, matchInteger,
-                  matchText, matchDate, reifyAnyValues)
+                  matchText, matchDate, reifyAnyValues, toMArray)
 
 import qualified Control.Category as Cat
 import qualified Data.Text as T
@@ -119,12 +119,15 @@ prism review preview = BiMap preview (Just . review)
 -- General purpose bimaps
 ----------------------------------------------------------------------------
 
+-- | Bimap for 'Either' and its left type
 _Left :: BiMap (Either l r) l
 _Left = prism Left (either Just (const Nothing))
 
+-- | Bimap for 'Either' and its right type
 _Right :: BiMap (Either l r) r
 _Right = prism Right (either (const Nothing) Just)
 
+-- | Bimap for 'Maybe'
 _Just :: BiMap (Maybe a) a
 _Just = prism Just id
 
@@ -139,63 +142,73 @@ mkAnyValueBiMap :: (forall t . Value t -> Maybe a)
 mkAnyValueBiMap matchValue toValue =
     BiMap (Just . AnyValue . toValue) (\(AnyValue value) -> matchValue value)
 
--- | Creates prism for 'Text' to 'AnyValue' with custom functions
+-- | Creates bimap for 'Text' to 'AnyValue' with custom functions
 _TextBy :: (a -> Text) -> (Text -> Maybe a) -> BiMap a AnyValue
 _TextBy toText parseText =
   mkAnyValueBiMap (matchText >=> parseText) (Text . toText)
 
--- | 'Bool' bimap for 'AnyValue'. Usually used with 'arrayOf' combinator.
+-- | 'Bool' bimap for 'AnyValue'. Usually used with 'bool' combinator.
 _Bool :: BiMap Bool AnyValue
 _Bool = mkAnyValueBiMap matchBool Bool
 
--- | 'Integer' bimap for 'AnyValue'. Usually used with 'arrayOf' combinator.
+-- | 'Integer' bimap for 'AnyValue'. Usually used with 'integer' combinator.
 _Integer :: BiMap Integer AnyValue
 _Integer = mkAnyValueBiMap matchInteger Integer
 
--- | 'Double' bimap for 'AnyValue'. Usually used with 'arrayOf' combinator.
+-- | 'Double' bimap for 'AnyValue'. Usually used with 'double' combinator.
 _Double :: BiMap Double AnyValue
 _Double = mkAnyValueBiMap matchDouble Double
 
--- | 'Text' bimap for 'AnyValue'. Usually used with 'arrayOf' combinator.
+-- | 'Text' bimap for 'AnyValue'. Usually used with 'text' combinator.
 _Text :: BiMap Text AnyValue
 _Text = mkAnyValueBiMap matchText Text
 
+-- | Zoned time bimap for 'AnyValue'. Usually used with 'zonedTime' combinator.
 _ZonedTime :: BiMap ZonedTime AnyValue
 _ZonedTime = mkAnyValueBiMap (matchDate >=> getTime) (Date . Zoned)
   where
     getTime (Zoned z) = Just z
     getTime _         = Nothing
 
+-- | Local time bimap for 'AnyValue'. Usually used with 'localTime' combinator.
 _LocalTime :: BiMap LocalTime AnyValue
 _LocalTime = mkAnyValueBiMap (matchDate >=> getTime) (Date . Local)
   where
     getTime (Local l) = Just l
     getTime _         = Nothing
 
+-- | Day bimap for 'AnyValue'. Usually used with 'day' combinator.
 _Day :: BiMap Day AnyValue
 _Day = mkAnyValueBiMap (matchDate >=> getTime) (Date . Day)
   where
     getTime (Day d) = Just d
     getTime _       = Nothing
 
+-- | Time of day bimap for 'AnyValue'. Usually used with 'timeOfDay' combinator.
 _TimeOfDay :: BiMap TimeOfDay AnyValue
 _TimeOfDay = mkAnyValueBiMap (matchDate >=> getTime) (Date . Hours)
   where
     getTime (Hours h) = Just h
     getTime _         = Nothing
 
+-- | Helper bimap for 'String' and 'Text'.
 _StringText :: BiMap String Text
 _StringText = iso T.pack T.unpack
 
+-- | 'String' bimap for 'AnyValue'. Usually used with 'string' combinator.
 _String :: BiMap String AnyValue
 _String = _StringText >>> _Text
 
+-- | Helper bimap for 'String' and types with 'Read' and 'Show' instances.
 _ReadString :: (Show a, Read a) => BiMap a String
 _ReadString = BiMap (Just . show) readMaybe
 
+-- | Bimap for 'AnyValue' and values with a `Read` and `Show` instance.
+-- Usually used with 'read' combinator.
 _Read :: (Show a, Read a) => BiMap a AnyValue
 _Read = _ReadString >>> _String
 
+-- | Helper bimap for 'Natural' and 'Integer'.
 _NaturalInteger :: BiMap Natural Integer
 _NaturalInteger = BiMap (Just . toInteger) maybeInteger
   where
@@ -204,9 +217,11 @@ _NaturalInteger = BiMap (Just . toInteger) maybeInteger
       | n < 0     = Nothing
       | otherwise = Just (fromIntegral n)
 
+-- | 'Natural' bimap for 'AnyValue'. Usually used with 'natural' combinator.
 _Natural :: BiMap Natural AnyValue
 _Natural = _NaturalInteger >>> _Integer
 
+-- | Helper bimap for 'Integer' and integral, bounded values.
 _BoundedInteger :: (Integral a, Bounded a) => BiMap a Integer
 _BoundedInteger = BiMap (Just . toInteger) maybeBounded
   where
@@ -216,57 +231,65 @@ _BoundedInteger = BiMap (Just . toInteger) maybeBounded
       | n > toInteger (maxBound :: a) = Nothing
       | otherwise                     = Just (fromIntegral n)
 
+-- | 'Word' bimap for 'AnyValue'. Usually used with 'word' combinator.
 _Word :: BiMap Word AnyValue
 _Word = _BoundedInteger >>> _Integer
 
+-- | 'Int' bimap for 'AnyValue'. Usually used with 'int' combinator.
 _Int :: BiMap Int AnyValue
 _Int = _BoundedInteger >>> _Integer
 
+-- | 'Float' bimap for 'AnyValue'. Usually used with 'float' combinator.
 _Float :: BiMap Float AnyValue
 _Float = iso realToFrac realToFrac >>> _Double
 
+-- | Helper bimap for 'Text' and strict 'ByteString'
 _ByteStringText :: BiMap ByteString Text
 _ByteStringText = prism T.encodeUtf8 maybeText
   where
     maybeText :: ByteString -> Maybe Text
     maybeText = either (const Nothing) Just . T.decodeUtf8'
 
+-- | 'ByteString' bimap for 'AnyValue'. Usually used with 'byteString' combinator.
 _ByteString:: BiMap ByteString AnyValue
 _ByteString = _ByteStringText >>> _Text
 
+-- | Helper bimap for 'Text' and lazy 'ByteString'
 _LByteStringText :: BiMap BL.ByteString Text
 _LByteStringText = prism (TL.encodeUtf8 . TL.fromStrict) maybeText
   where
     maybeText :: BL.ByteString -> Maybe Text
     maybeText = either (const Nothing) (Just . TL.toStrict) . TL.decodeUtf8'
 
+-- | Lazy 'ByteString' bimap for 'AnyValue'. Usually used with 'lazyByteString'
+-- combinator.
 _LByteString:: BiMap BL.ByteString AnyValue
 _LByteString = _LByteStringText >>> _Text
 
--- | 'Array' bimap for 'AnyValue'. Usually used with 'arrayOf' combinator.
+-- | Takes a bimap of a value and returns a bimap of a list of values and 'Anything'
+-- as an array. Usually used with 'arrayOf' combinator.
 _Array :: BiMap a AnyValue -> BiMap [a] AnyValue
 _Array elementBimap = BiMap
     { forward = mapM (forward elementBimap) >=> fmap AnyValue . toMArray
     , backward = \(AnyValue val) -> matchArray (backward elementBimap) val
     }
 
+-- | Takes a bimap of a value and returns a bimap of a non-empty list of values
+-- and 'Anything' as an array. Usually used with 'nonEmptyOf' combinator.
 _NonEmpty :: BiMap a AnyValue -> BiMap (NE.NonEmpty a) AnyValue
 _NonEmpty bimap = BiMap (Just . NE.toList) NE.nonEmpty >>> _Array bimap
 
+-- | Takes a bimap of a value and returns a bimap of a set of values and 'Anything'
+-- as an array. Usually used with 'setOf' combinator.
 _Set :: (Ord a) => BiMap a AnyValue -> BiMap (S.Set a) AnyValue
 _Set bimap = iso S.toList S.fromList >>> _Array bimap
 
+-- | Takes a bimap of a value and returns a bimap of a has set of values and
+-- 'Anything' as an array. Usually used with 'hashSetOf' combinator.
 _HashSet :: (Eq a, Hashable a) => BiMap a AnyValue -> BiMap (HS.HashSet a) AnyValue
 _HashSet bimap = iso HS.toList HS.fromList >>> _Array bimap
 
+-- | Bimap of 'IntSet' and 'Anything' as an array. Usually used with
+-- 'intSet' combinator.
 _IntSet :: BiMap IS.IntSet AnyValue
 _IntSet = iso IS.toList IS.fromList >>> _Array _Int
-
--- TODO: move somewhere else?
-{- | Function for creating 'Array' from list of 'AnyValue'.
--}
-toMArray :: [AnyValue] -> Maybe (Value 'TArray)
-toMArray [] = Just $ Array []
-toMArray (AnyValue x : xs) = case reifyAnyValues x xs of
-    Left _     -> Nothing
-    Right vals -> Just $ Array (x : vals)

--- a/src/Toml/BiMap.hs
+++ b/src/Toml/BiMap.hs
@@ -17,7 +17,7 @@ module Toml.BiMap
        , _TextBy
        , _NaturalInteger
        , _StringText
-       , _ShowString
+       , _ReadString
        , _BoundedInteger
        , _ByteStringText
        , _LByteStringText
@@ -33,7 +33,7 @@ module Toml.BiMap
        , _Day
        , _TimeOfDay
        , _String
-       , _Show
+       , _Read
        , _Natural
        , _Word
        , _Int
@@ -190,11 +190,11 @@ _StringText = iso T.pack T.unpack
 _String :: BiMap String AnyValue
 _String = _StringText >>> _Text
 
-_ShowString :: (Show a, Read a) => BiMap a String
-_ShowString = BiMap (Just . show) readMaybe
+_ReadString :: (Show a, Read a) => BiMap a String
+_ReadString = BiMap (Just . show) readMaybe
 
-_Show :: (Show a, Read a) => BiMap a AnyValue
-_Show = _ShowString >>> _String
+_Read :: (Show a, Read a) => BiMap a AnyValue
+_Read = _ReadString >>> _String
 
 _NaturalInteger :: BiMap Natural Integer
 _NaturalInteger = BiMap (Just . toInteger) maybeInteger

--- a/src/Toml/Type/AnyValue.hs
+++ b/src/Toml/Type/AnyValue.hs
@@ -6,6 +6,7 @@
 module Toml.Type.AnyValue
        ( AnyValue (..)
        , reifyAnyValues
+       , toMArray
 
          -- * Matching
        , liftMatch
@@ -79,3 +80,10 @@ liftMatch fromAnyValue = fromAnyValue . AnyValue
 reifyAnyValues :: Value t -> [AnyValue] -> Either TypeMismatchError [Value t]
 reifyAnyValues _ []                 = Right []
 reifyAnyValues v (AnyValue av : xs) = sameValue v av >>= \Refl -> (av :) <$> reifyAnyValues v xs
+
+-- | Function for creating 'Array' from list of 'AnyValue'.
+toMArray :: [AnyValue] -> Maybe (Value 'TArray)
+toMArray [] = Just $ Array []
+toMArray (AnyValue x : xs) = case reifyAnyValues x xs of
+    Left _     -> Nothing
+    Right vals -> Just $ Array (x : vals)

--- a/src/Toml/Type/AnyValue.hs
+++ b/src/Toml/Type/AnyValue.hs
@@ -22,7 +22,7 @@ import Control.DeepSeq (NFData, rnf)
 import Data.Text (Text)
 import Data.Type.Equality ((:~:) (..))
 
-import Toml.Type.Value (DateTime, TValue, TypeMismatchError, Value (..), sameValue)
+import Toml.Type.Value (DateTime, TValue (..), TypeMismatchError, Value (..), sameValue)
 
 -- | Existential wrapper for 'Value'.
 data AnyValue = forall (t :: TValue) . AnyValue (Value t)


### PR DESCRIPTION
#130 

- I replaced the implementation of `arrayOf ` by simply using `match`. It works, but it seems too simple, am I missing anything?
- Because I've removed the big implementation of `arrayOf`, `matchValueBackward` wasn't needed, so I removed it as well, it felt like it only existed for that purpose. I can bring it back in if needed.
- I'm not sure if we need to keep `dimapNum`, the type casting logic feels like it should stay in `BiMap.hs`
- I re-grouped the exports of `BiMap.hs`
- All tests pass, but we should really add more (related to #119) 
- I really think we should rename `_Array` and `arrayOf` as `_List` and `listOf` since the name reflects the Haskell type (just like with `_Word`), not the way data is stored in the `Anything`