### PR TITLE
[#129] Allow underscore in floats

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,8 @@ The change log is available [on GitHub][2].
   Adding EDSL support for arrays of tables
 * [#149](https://github.com/kowainik/tomland/issues/149):
   Removing records syntax from `PrefixTree`.
+* [#146](https://github.com/kowainik/tomland/issues/146):
+  Allow underscores in floats.
 
 ## 0.5.0 — Nov 12, 2018
 
@@ -38,7 +40,7 @@ The change log is available [on GitHub][2].
 
   _Migration guide:_ reverse order of composition when using `BiMap`s.
 * [#98](https://github.com/kowainik/tomland/issues/98):
-  Implement bencmarks for `tomland` and compare with `htoml` and `htoml-megaparsec` libraries.
+  Implement benchmarks for `tomland` and compare with `htoml` and `htoml-megaparsec` libraries.
 * [#130](https://github.com/kowainik/tomland/issues/130):
   Added combinators to `Toml.Bi.Combinators`.
 * [#115](https://github.com/kowainik/tomland/issues/115):

--- a/src/Toml/Parser/Value.hs
+++ b/src/Toml/Parser/Value.hs
@@ -23,7 +23,6 @@ import Data.Text (Text)
 import Data.Time (LocalTime (..), ZonedTime (..), fromGregorianValid, makeTimeOfDayValid,
                   minutesToTimeZone)
 import Text.Read (readMaybe)
-import Text.Read (readMaybe)
 
 import Toml.Parser.Core (Parser, alphaNumChar, anySingle, binary, char, digitChar, eol,
                          hexDigitChar, hexadecimal, lexeme, octal, satisfy, sc, signed, space,
@@ -173,14 +172,14 @@ doubleP = lexeme (signed sc (num <|> inf <|> nan)) <?> "double"
     nan = 0 / 0 <$ string "nan"
 
 floatP :: Parser Double
-floatP = check =<< readMaybe . concat <$> sequence [ digits, expo <|> dot ]
+floatP = check . readMaybe =<< mconcat [ digits, expo <|> dot ]
   where
     check = maybe (fail "Not a float") return
 
     digits, dot, expo :: Parser String
     digits = concat <$> sepBy1 (some digitChar) (char '_')
-    dot = concat <$> sequence [pure <$> char '.', digits, option "" expo]
-    expo = concat <$> sequence
+    dot = mconcat [pure <$> char '.', digits, option "" expo]
+    expo = mconcat
              [ pure <$> (char 'e' <|> char 'E')
              , pure <$> option '+' (char '+' <|> char '-')
              , digits

--- a/test/Test/Toml/Parsing/Unit.hs
+++ b/test/Test/Toml/Parsing/Unit.hs
@@ -8,8 +8,8 @@ import Test.Hspec.Megaparsec (parseSatisfies, shouldFailOn, shouldParse)
 import Test.Tasty.Hspec (Spec, context, describe, it)
 import Text.Megaparsec (parse)
 
-import Toml.Parser.Value (arrayP, boolP, dateTimeP, doubleP, integerP, keyP, textP)
 import Toml.Parser.TOML (hasKeyP, tableHeaderP, tomlP)
+import Toml.Parser.Value (arrayP, boolP, dateTimeP, doubleP, integerP, keyP, textP)
 import Toml.PrefixTree (Key (..), Piece (..), fromList)
 import Toml.Type (AnyValue (..), DateTime (..), TOML (..), UValue (..), Value (..))
 
@@ -113,22 +113,24 @@ spec_Parser = do
             boolFailOn "fAlSE"
 
     describe "doubleP" $ do
-        it
-                "can parse a number which consists of an integral part, and a fractional part"
+        it "can parse a number which consists of an integral part, and a fractional part"
             $ do
                   parseDouble "+1.0"   1.0
                   parseDouble "3.1415" 3.1415
                   parseDouble "0.0"    0.0
                   parseDouble "-0.01"  (-0.01)
-        it
-                "can parse a number which consists of an integral part, and an exponent part"
+        it "can parse a number which consists of an integral part, and an exponent part"
             $ do
                   parseDouble "5e+22" 5e+22
                   parseDouble "1e6"   1e6
                   parseDouble "-2E-2" (-2E-2)
-        it
-                "can parse a number which consists of an integral, a fractional, and an exponent part"
+        it "can parse a number which consists of an integral, a fractional, and an exponent part"
             $ parseDouble "6.626e-34" 6.626e-34
+        it "can parse a number with underscores"
+            $ do
+                  parseDouble "5e+2_2" 5e+22
+                  parseDouble "1.1_1e6"   1.11e6
+                  parseDouble "-2_2.21_9E-0_2" (-22.219E-2)
         it "can parse sign-prefixed zero" $ do
             parseDouble "+0.0" 0.0
             parseDouble "-0.0" (-0.0)

--- a/test/Test/Toml/Parsing/Unit.hs
+++ b/test/Test/Toml/Parsing/Unit.hs
@@ -126,8 +126,7 @@ spec_Parser = do
                   parseDouble "-2E-2" (-2E-2)
         it "can parse a number which consists of an integral, a fractional, and an exponent part"
             $ parseDouble "6.626e-34" 6.626e-34
-        it "can parse a number with underscores"
-            $ do
+        it "can parse a number with underscores" $ do
                   parseDouble "5e+2_2" 5e+22
                   parseDouble "1.1_1e6"   1.11e6
                   parseDouble "-2_2.21_9E-0_2" (-22.219E-2)


### PR DESCRIPTION
Resolves #129 

### :white_check_mark: Check list
- [x] CHANGELOG
- [x] New/fixed features work as expected (Added unit tests).
- [x] There are no warnings during compilation.
- [x] `hlint .` output is: _No Hints_ .
- [x] The code is formatted with the `stylish-haskell` tool 
      using `stylish-haskell.yaml` file in the repository.
- [x] The code style of the files you changed is preserved.
- [ ] Commit messages are in the proper format.
      Start the first line of the commit with the issue number in square parentheses.