### PR TITLE
Add benchmarks with toml-parser library

### DIFF
--- a/benchmark/Benchmark/Htoml.hs
+++ b/benchmark/Benchmark/Htoml.hs
@@ -7,13 +7,13 @@
 
 module Benchmark.Htoml
        ( decode
-       , convert
        , parse
+       , convert
        ) where
 
-import Benchmark.Type (HaskellType)
 import Control.DeepSeq (NFData, rnf, rwhnf)
 import Data.Aeson.Types (parseEither, parseJSON)
+import Data.Semigroup ((<>))
 import Data.Text (Text)
 import GHC.Generics (Generic)
 import Text.Parsec.Error (ParseError)
@@ -21,20 +21,22 @@ import Text.Parsec.Error (ParseError)
 import "htoml" Text.Toml (parseTomlDoc)
 import "htoml" Text.Toml.Types (Node (..), Table, toJSON)
 
+import Benchmark.Type (HaskellType)
+
 
 -- | Decode toml file to Haskell type.
 decode :: Text -> Either String HaskellType
 decode txt = case parseTomlDoc "" txt of
-    Left _     -> error "Parsing failed"
+    Left err   -> error $ "'htoml' parsing failed: " <> show err
     Right toml -> convert toml
+
+-- | Wrapper on htoml's 'parseTomlDoc'
+parse :: Text -> Either ParseError Table
+parse = parseTomlDoc ""
 
 -- | Convert from already parsed toml to Haskell type.
 convert :: Table -> Either String HaskellType
 convert = parseEither parseJSON . toJSON
-
--- | Wrapper on htoml's parseTomlDoc
-parse :: Text -> Either ParseError Table
-parse = parseTomlDoc ""
 
 deriving instance NFData Node
 deriving instance Generic Node

--- a/benchmark/Benchmark/HtomlMegaparsec.hs
+++ b/benchmark/Benchmark/HtomlMegaparsec.hs
@@ -3,17 +3,24 @@
 {-# LANGUAGE PackageImports #-}
 
 module Benchmark.HtomlMegaparsec
-       ( convert
-       , decode
+       ( decode
        , parse
+       , convert
        ) where
 
 import Data.Aeson.Types (ToJSON, parseEither, parseJSON, toJSON)
+import Data.Semigroup ((<>))
 import Data.Text (Text)
+
 import "htoml-megaparsec" Text.Toml (Node (..), Table, TomlError, parseTomlDoc)
 
 import Benchmark.Type (HaskellType)
 
+-- | Decode toml file to Haskell type.
+decode :: Text -> Either String HaskellType
+decode txt = case parseTomlDoc "log" txt of
+    Left err   -> error $ "'htoml-megaparsec' parsing failed: " <> show err
+    Right toml -> convert toml
 
 -- | Wrapper on htoml-megaparsec's parseTomlDoc
 parse :: Text -> Either TomlError Table
@@ -22,12 +29,6 @@ parse = parseTomlDoc "log"
 -- | Convert from already parsed toml to Haskell type.
 convert :: Table -> Either String HaskellType
 convert = parseEither parseJSON . toJSON
-
--- | Decode toml file to Haskell type.
-decode :: Text -> Either String HaskellType
-decode txt = case parseTomlDoc "log" txt of
-    Left _     -> error "Parsing failed"
-    Right toml -> convert toml
 
 -- | 'ToJSON' instances for the 'Node' type that produce Aeson (JSON)
 -- in line with the TOML specification.

--- a/benchmark/Benchmark/TomlParser.hs
+++ b/benchmark/Benchmark/TomlParser.hs
@@ -1,0 +1,91 @@
+{-# OPTIONS_GHC -fno-warn-orphans #-}
+
+{-# LANGUAGE DeriveAnyClass      #-}
+{-# LANGUAGE DeriveGeneric       #-}
+{-# LANGUAGE ScopedTypeVariables #-}
+{-# LANGUAGE StandaloneDeriving  #-}
+
+module Benchmark.TomlParser
+       ( decode
+       , parse
+       , convert
+       ) where
+
+import Control.DeepSeq (NFData, rnf, rwhnf)
+import Data.Semigroup ((<>))
+import Data.Text (Text)
+import GHC.Generics (Generic)
+
+import Benchmark.Type (FruitInside (..), HaskellType (..), SizeInside (..))
+
+import qualified TOML
+
+
+-- | Decode toml file to Haskell type.
+decode :: Text -> Either String HaskellType
+decode txt = case parse txt of
+    Left err   -> error $ "'toml-parser' parsing failed: " <> show err
+    Right toml -> maybe (Left "Some error during conversion") Right $ convert toml
+
+-- | Wrapper over 'TOML.parseTOML'
+parse :: Text -> Either TOML.TOMLError [(Text, TOML.Value)]
+parse = TOML.parseTOML
+
+-- | Convert from already parsed toml to Haskell type.
+convert :: [(Text, TOML.Value)] -> Maybe HaskellType
+convert toml = do
+    TOML.String htTitle <- lookup "title" toml
+    TOML.Double htAtom <- lookup "atom" toml
+    TOML.Bool htCash <- lookup "cash" toml
+
+    TOML.List tomlWords <- lookup "words" toml
+    htWords <- mapM matchText tomlWords
+
+    TOML.List tomlBools <- lookup "bool" toml
+    htBool <- mapM matchBool tomlBools
+
+    TOML.ZonedTimeV htToday <- lookup "today" toml
+
+    TOML.List tomlInts <- lookup "ints" toml
+    htInteger <- mapM matchInteger tomlInts
+
+    TOML.Table fruit <- lookup "fruit" toml
+    htFruit <- do
+        TOML.String fiName <- lookup "name" fruit
+        TOML.String fiDescription <- lookup "description" fruit
+        pure FruitInside{..}
+
+    TOML.Table size <- lookup "size" toml
+    htSize <- do
+        TOML.List dimensions <- lookup "dimensions" size
+        arrays :: [[TOML.Value]] <- mapM matchArray dimensions
+        unSize <- mapM (mapM matchDouble) arrays
+        pure SizeInside{..}
+
+    pure HaskellType{..}
+
+matchText :: TOML.Value -> Maybe Text
+matchText (TOML.String t) = Just t
+matchText _               = Nothing
+
+matchBool :: TOML.Value -> Maybe Bool
+matchBool (TOML.Bool b) = Just b
+matchBool _             = Nothing
+
+matchInteger :: TOML.Value -> Maybe Integer
+matchInteger (TOML.Integer i) = Just i
+matchInteger _                = Nothing
+
+matchArray :: TOML.Value -> Maybe [TOML.Value]
+matchArray (TOML.List a) = Just a
+matchArray _             = Nothing
+
+matchDouble :: TOML.Value -> Maybe Double
+matchDouble (TOML.Double d) = Just d
+matchDouble _               = Nothing
+
+deriving instance Generic TOML.Value
+deriving instance NFData  TOML.Value
+
+instance NFData TOML.TOMLError where
+  rnf = rwhnf

--- a/benchmark/Benchmark/Tomland.hs
+++ b/benchmark/Benchmark/Tomland.hs
@@ -1,7 +1,7 @@
 module Benchmark.Tomland
-       ( convert
-       , decode
+       ( decode
        , parse
+       , convert
        ) where
 
 import Data.Text (Text)
@@ -11,6 +11,11 @@ import Toml (DecodeException, TOML, TomlCodec, parse, (.=))
 
 import qualified Toml
 
+decode :: Text -> Either DecodeException HaskellType
+decode = Toml.decode codec
+
+convert :: TOML -> Either DecodeException HaskellType
+convert = Toml.runTomlCodec codec
 
 -- | Codec to use in tomland decode and convert functions.
 codec :: TomlCodec HaskellType
@@ -31,11 +36,4 @@ insideF = FruitInside
     <*> Toml.text "description" .= fiDescription
 
 insideS :: TomlCodec SizeInside
-insideS = Toml.dimap unSize SizeInside $
-    Toml.arrayOf (Toml._Array Toml._Double) "dimensions"
-
-convert :: TOML -> Either DecodeException HaskellType
-convert = Toml.runTomlCodec codec
-
-decode :: Text -> Either DecodeException HaskellType
-decode = Toml.decode codec
+insideS = Toml.diwrap $ Toml.arrayOf (Toml._Array Toml._Double) "dimensions"

--- a/benchmark/Benchmark/Type.hs
+++ b/benchmark/Benchmark/Type.hs
@@ -2,9 +2,9 @@
 {-# LANGUAGE DeriveGeneric  #-}
 
 module Benchmark.Type
-       ( HaskellType(..)
-       , FruitInside(..)
-       , SizeInside(..)
+       ( HaskellType (..)
+       , FruitInside (..)
+       , SizeInside (..)
        ) where
 
 import Control.DeepSeq (NFData)

--- a/benchmark/Main.hs
+++ b/benchmark/Main.hs
@@ -7,6 +7,7 @@ import Gauge.Main (bench, bgroup, defaultMain, nf)
 import qualified Benchmark.Htoml as Htoml
 import qualified Benchmark.HtomlMegaparsec as HtomlM
 import qualified Benchmark.Tomland as Tomland
+import qualified Benchmark.TomlParser as TomlParser
 import qualified Data.Text.IO as TIO
 
 
@@ -17,20 +18,24 @@ main = do
     Right tomlandVal <- pure $ Tomland.parse txt
     Right htomlVal <- pure $ Htoml.parse txt
     Right htomlMegaVal <- pure $ HtomlM.parse txt
+    Right tomlParserVal <- pure $ TomlParser.parse txt
     defaultMain
         [ bgroup "Parse"
             [ bench "tomland"          $ nf Tomland.parse txt
             , bench "htoml"            $ nf Htoml.parse txt
             , bench "htoml-megaparsec" $ nf HtomlM.parse txt
+            , bench "toml-parser"      $ nf TomlParser.parse txt
             ]
         , bgroup "Convert"
             [ bench "tomland"          $ nf Tomland.convert tomlandVal
             , bench "htoml"            $ nf Htoml.convert htomlVal
             , bench "htoml-megaparsec" $ nf HtomlM.convert htomlMegaVal
+            , bench "toml-parser"      $ nf TomlParser.convert tomlParserVal
             ]
         , bgroup "Decode"
             [ bench "tomland"          $ nf Tomland.decode txt
             , bench "htoml"            $ nf Htoml.decode txt
             , bench "htoml-megaparsec" $ nf HtomlM.decode txt
+            , bench "toml-parser"      $ nf TomlParser.decode txt
             ]
         ]

--- a/stack.yaml
+++ b/stack.yaml
@@ -4,3 +4,4 @@ extra-deps:
   - htoml-megaparsec-2.1.0.3
   - composition-prelude-2.0.2.1  # needed for htoml-megaparsec
   - tasty-hedgehog-0.2.0.0
+  - toml-parser-0.1.0.0

--- a/tomland.cabal
+++ b/tomland.cabal
@@ -144,6 +144,7 @@ benchmark tomland-benchmark
                       Benchmark.Htoml
                       Benchmark.HtomlMegaparsec
                       Benchmark.Tomland
+                      Benchmark.TomlParser
 
   ghc-options:        -Wall
                       -threaded
@@ -168,6 +169,7 @@ benchmark tomland-benchmark
                     , parsec
                     , text
                     , time
+                    , toml-parser ^>= 0.1.0.0
                     , tomland
 
   default-language:   Haskell2010


### PR DESCRIPTION
Added benchmarks with `toml-parser` library. `tomland` actually is not that fast comparing to other libraries... But, again, we can improve performance later :slightly_smiling_face: 