### PR TITLE
Implement a better generator for `Piece`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,10 @@
 tomland uses [PVP Versioning][1].
 The changelog is available [on GitHub][2].
 
+## 1.0.1
+* [#177](https://github.com/kowainik/tomland/issues/177):
+  Add a more extensive property generator for `Piece`.
+
 ## 1.0.0 — Jan 14, 2019
 
 * [#13](https://github.com/kowainik/tomland/issues/13):

--- a/cabal.project
+++ b/cabal.project
@@ -1,0 +1,1 @@
+allow-newer: htoml-megaparsec:unordered-containers

--- a/cabal.project
+++ b/cabal.project
@@ -1,1 +1,3 @@
+packages: .
+
 allow-newer: htoml-megaparsec:unordered-containers

--- a/test/Test/Toml/Gen.hs
+++ b/test/Test/Toml/Gen.hs
@@ -71,6 +71,7 @@ import Toml.PrefixTree (pattern (:||), Key (..), Piece (..), PrefixMap, PrefixTr
 import Toml.Type (AnyValue (..), TOML (..), TValue (..), Value (..))
 
 import qualified Data.ByteString.Lazy as LB
+import qualified Data.Char as Char
 import qualified Data.List.NonEmpty as NE
 import qualified Data.Text as Text
 import qualified Data.Text.Lazy as L
@@ -109,14 +110,14 @@ genPiece = Piece <$> Gen.choice [bare, quoted]
   where
     alphadashes :: MonadGen m => m Char
     alphadashes = Gen.choice [Gen.alphaNum, Gen.element "_-"]
-    unicodeNotNull :: MonadGen m => m Char
-    unicodeNotNull = Gen.filter (/= '\NUL') Gen.unicode
+    notControl :: MonadGen m => m Char
+    notControl = Gen.filter (not . Char.isControl) Gen.unicode
     bare :: MonadGen m => m Text
     bare = Gen.text (Range.constant 1 10) alphadashes
     wrapChar :: Char -> Text -> Text
     wrapChar c = Text.cons c . (`Text.append` Text.singleton c)
     quotedWith :: MonadGen m => Char -> m Text
-    quotedWith c = wrapChar c <$> Gen.text (Range.constant 1 10) (Gen.filter (/= c) unicodeNotNull)
+    quotedWith c = wrapChar c <$> Gen.text (Range.constant 1 10) (Gen.filter (/= c) notControl)
     quoted :: MonadGen m => m Text
     quoted = Gen.choice [quotedWith '"', quotedWith '\'']
 

--- a/test/Test/Toml/Gen.hs
+++ b/test/Test/Toml/Gen.hs
@@ -109,12 +109,14 @@ genPiece = Piece <$> Gen.choice [bare, quoted]
   where
     alphadashes :: MonadGen m => m Char
     alphadashes = Gen.choice [Gen.alphaNum, Gen.element "_-"]
+    unicodeNotNull :: MonadGen m => m Char
+    unicodeNotNull = Gen.filter (/= '\NUL') Gen.unicode
     bare :: MonadGen m => m Text
     bare = Gen.text (Range.constant 1 10) alphadashes
     wrapChar :: Char -> Text -> Text
-    wrapChar c = Text.cons c . (`Text.append` (Text.singleton c))
+    wrapChar c = Text.cons c . (`Text.append` Text.singleton c)
     quotedWith :: MonadGen m => Char -> m Text
-    quotedWith c = wrapChar c <$> Gen.text (Range.constant 1 10) (Gen.filter (/= c) Gen.unicode)
+    quotedWith c = wrapChar c <$> Gen.text (Range.constant 1 10) (Gen.filter (/= c) unicodeNotNull)
     quoted :: MonadGen m => m Text
     quoted = Gen.choice [quotedWith '"', quotedWith '\'']
 


### PR DESCRIPTION
This PR addresses #177.

This modifies the generator for `Piece` to either generate a bare piece, with alphanumeric and dashes, otherwise it generates either single quoted `''` or double quoted `""` strings containing arbitrary unicode.

All existing tests pass, thankfully.

I've updated the changelog with version 1.0.1, not sure if this is the right one to have there.