### PR TITLE
Use extra-source-dirs instead of data-dir, see #141

### DIFF
--- a/tomland.cabal
+++ b/tomland.cabal
@@ -32,7 +32,7 @@ category:            TOML, Text, Configuration
 build-type:          Simple
 extra-doc-files:     README.md
                    , CHANGELOG.md
-data-dir:            test/golden
+extra-source-files:  test/golden/*.golden
 tested-with:         GHC == 8.2.2
                    , GHC == 8.4.4
                    , GHC == 8.6.3


### PR DESCRIPTION
Here's how I verified that this worked from the tarball on my machine:

```
$ stack sdist
$ cp .stack-work/dist/x86_64-osx/Cabal-2.4.0.1/tomland-1.0.0.tar.gz ~/scratch/
$ cd ~/scratch/
$ tar -xzf tomland-1.0.0.tar.gz
$ cd tomland-1.0.0
$ edit stack.yaml # see below
$ stack build --test --bench --no-run-benchmarks --fast
```

```yaml
# stack.yaml
resolver: nightly-2019-02-25
extra-deps:
- htoml-megaparsec-2.1.0.3
- toml-parser-0.1.0.0
- composition-prelude-2.0.2.1
```
