### PR TITLE
[#195] Fix parser exponential behavior

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,8 @@ The changelog is available [on GitHub][2].
 * [#187](https://github.com/kowainik/tomland/issues/187):
   Bump up to `hedgehog-1.0`.
 * Support GHC 8.6.5
+* [#195](https://github.com/kowainik/tomland/issues/195):
+  Fixed an exponential behavior for parsing nested table of arrays.
 
 ## 1.0.0 — Jan 14, 2019
 

--- a/src/Toml/Parser/Core.hs
+++ b/src/Toml/Parser/Core.hs
@@ -9,6 +9,7 @@ module Toml.Parser.Core
        , lexeme
        , sc
        , text
+       , eof
        ) where
 
 import Control.Applicative (Alternative (empty))
@@ -16,7 +17,8 @@ import Control.Applicative (Alternative (empty))
 import Data.Text (Text)
 import Data.Void (Void)
 
-import Text.Megaparsec (Parsec, anySingle, errorBundlePretty, match, parse, satisfy, try, (<?>))
+import Text.Megaparsec (Parsec, anySingle, eof, errorBundlePretty, match, parse, satisfy, try,
+                        (<?>))
 import Text.Megaparsec.Char (alphaNumChar, char, digitChar, eol, hexDigitChar, space, space1,
                              string, tab)
 import Text.Megaparsec.Char.Lexer (binary, float, hexadecimal, octal, signed, skipLineComment,

--- a/src/Toml/Parser/Core.hs
+++ b/src/Toml/Parser/Core.hs
@@ -9,7 +9,6 @@ module Toml.Parser.Core
        , lexeme
        , sc
        , text
-       , eof
        ) where
 
 import Control.Applicative (Alternative (empty))

--- a/src/Toml/Parser/TOML.hs
+++ b/src/Toml/Parser/TOML.hs
@@ -69,7 +69,7 @@ inlineTableP = between
     (tomlFromInline <$> hasKeyP `sepEndBy` text ",")
 
 
--- | Parser for an array of tables.
+-- | Parser for an array of tables under a certain key.
 tableArrayP :: Key -> Parser (NonEmpty TOML)
 tableArrayP key =
     tableP (Just key) `NC.sepBy1` sameKeyP key tableArrayNameP
@@ -78,7 +78,7 @@ tableArrayP key =
 tomlP :: Parser TOML
 tomlP = sc *> tableP Nothing <* eof
 
--- | Parser for full 'TOML' under a certain key
+-- | Parser for a table under a certain key
 tableP :: Maybe Key -> Parser TOML
 tableP key = do
     (val, inline)  <- distributeEithers <$> many hasKeyP
@@ -100,8 +100,9 @@ tableP key = do
         , tomlTableArrays = HashMap.fromList array
         }
 
--- | @childKeyP key p@ returns the result of @p@ if the key returned by @p@ is
--- a child key of the @key@, and fails otherwise.
+-- | @childKeyP (Just key) p@ checks if the result of @p@ if a child key of
+-- @key@ and returns the difference of the keys and the child key.
+-- @childKeyP Nothing p@ is only called from @tomlP@ (no parent key).
 childKeyP :: Maybe Key -> Parser Key -> Parser (Key, Key)
 childKeyP Nothing parser = try $ do
   k <- parser

--- a/src/Toml/Parser/TOML.hs
+++ b/src/Toml/Parser/TOML.hs
@@ -12,12 +12,12 @@ module Toml.Parser.TOML
        ) where
 
 import Control.Applicative (Alternative (..))
-import Control.Monad.Combinators (between, eitherP, optional, sepEndBy)
-import Data.List.NonEmpty (NonEmpty (..), (<|))
+import Control.Monad.Combinators (between, eitherP, sepEndBy)
+import Data.List.NonEmpty (NonEmpty (..))
 import Data.Semigroup ((<>))
 import Data.Text (Text)
 
-import Toml.Parser.Core (Parser, alphaNumChar, char, lexeme, sc, text, try)
+import Toml.Parser.Core (Parser, alphaNumChar, char, eof, lexeme, sc, text, try)
 import Toml.Parser.String (basicStringP, literalStringP)
 import Toml.Parser.Value (anyValueP)
 import Toml.PrefixTree (Key (..), KeysDiff (..), Piece (..), fromList, keysDiff)
@@ -46,7 +46,7 @@ keyComponentP = Piece <$>
 
 -- | Parser for 'Key': dot-separated list of 'Piece'.
 keyP :: Parser Key
-keyP = Key <$> NC.sepBy1 keyComponentP (char '.')
+keyP = Key <$> keyComponentP `NC.sepBy1` char '.'
 
 -- | Parser for table name: 'Key' inside @[]@.
 tableNameP :: Parser Key
@@ -68,46 +68,31 @@ inlineTableP = between
     (text "{") (text "}")
     (tomlFromInline <$> hasKeyP `sepEndBy` text ",")
 
--- | Parser for a table.
-tableP :: Parser (Key, TOML)
-tableP = do
-    key  <- tableNameP
-    toml <- subTableContent key
-    pure (key, toml)
 
 -- | Parser for an array of tables.
-tableArrayP :: Parser (Key, NonEmpty TOML)
-tableArrayP = do
-    key       <- tableArrayNameP
-    localToml <- subTableContent key
-    more      <- optional $ sameKeyP key tableArrayP
-    case more of
-        Nothing         -> pure (key, localToml :| [])
-        Just (_, tomls) -> pure (key, localToml <| tomls)
+tableArrayP :: Key -> Parser (NonEmpty TOML)
+tableArrayP key =
+    tableP (Just key) `NC.sepBy1` sameKeyP key tableArrayNameP
 
 -- | Parser for a '.toml' file
 tomlP :: Parser TOML
-tomlP = do
-    sc
-    (val, inline)  <- distributeEithers <$> many hasKeyP
-    (table, array) <- fmap distributeEithers
-        $ many
-        $ eitherPairP (try tableP) tableArrayP
-
-    pure TOML
-        { tomlPairs       = HashMap.fromList val
-        , tomlTables      = fromList $ inline ++ table
-        , tomlTableArrays = HashMap.fromList array
-        }
+tomlP = sc *> tableP Nothing <* eof
 
 -- | Parser for full 'TOML' under a certain key
-subTableContent :: Key -> Parser TOML
-subTableContent key = do
+tableP :: Maybe Key -> Parser TOML
+tableP key = do
     (val, inline)  <- distributeEithers <$> many hasKeyP
     (table, array) <- fmap distributeEithers
         $ many
-        $ childKeyP key
-        $ eitherPairP (try tableP) tableArrayP
+        $ eitherPairP
+            (try $ do
+              (kDiff, k) <- childKeyP key tableNameP
+              t <- tableP (Just k)
+              pure (kDiff, t))
+            (do
+              (kDiff, k) <- childKeyP key tableArrayNameP
+              a <- tableArrayP k
+              pure (kDiff, a))
 
     pure TOML
         { tomlPairs       = HashMap.fromList val
@@ -117,20 +102,23 @@ subTableContent key = do
 
 -- | @childKeyP key p@ returns the result of @p@ if the key returned by @p@ is
 -- a child key of the @key@, and fails otherwise.
-childKeyP :: Key -> Parser (Key, a) -> Parser (Key, a)
-childKeyP key p = try $ do
-    (k, x) <- p
+childKeyP :: Maybe Key -> Parser Key -> Parser (Key, Key)
+childKeyP Nothing parser = try $ do
+  k <- parser
+  pure (k, k)
+childKeyP (Just key) parser = try $ do
+    k <- parser
     case keysDiff key k of
-        FstIsPref k' -> pure (k', x)
-        _            -> fail $ show k ++ " is not a child key of " ++ show key
+        FstIsPref d -> pure (d, k)
+        _           -> fail $ show k ++ " is not a child key of " ++ show key
 
 -- | @sameKeyP key p@ returns the result of @p@ if the key returned by @p@ is
 -- the same as @key@, and fails otherwise.
-sameKeyP :: Key -> Parser (Key, a) -> Parser (Key, a)
+sameKeyP :: Key -> Parser Key -> Parser Key
 sameKeyP key parser = try $ do
-    (k, x) <- parser
+    k <- parser
     case keysDiff key k of
-        Equal -> pure (k, x)
+        Equal -> pure k
         _     -> fail $ show k ++ " is not the same as " ++ show key
 
 -- Helper functions

--- a/test/Test/Toml/Gen.hs
+++ b/test/Test/Toml/Gen.hs
@@ -179,9 +179,9 @@ genToml = Gen.recursive
              $ Gen.list (Range.linear 0 5)
              $ (,) <$> genKey <*> genToml
     arrays = fmap fromList $
-             Gen.list (Range.linear 0 5) $ do
+             Gen.list (Range.linear 0 10) $ do
                key <- genKey
-               arr <- Gen.list (Range.linear 1 5) genToml
+               arr <- Gen.list (Range.linear 1 10) genToml
                return (key, NE.fromList arr)
 
 -- Date generators

--- a/test/Test/Toml/Parsing/Unit.hs
+++ b/test/Test/Toml/Parsing/Unit.hs
@@ -13,7 +13,7 @@ import Text.Megaparsec (Parsec, ShowErrorComponent, Stream, parse)
 
 import Toml.Edsl (mkToml, table, tableArray, (=:))
 import Toml.Parser.String (textP)
-import Toml.Parser.TOML (hasKeyP, keyP, tableArrayP, tableP, tomlP)
+import Toml.Parser.TOML (keyP, tomlP)
 import Toml.Parser.Value (arrayP, boolP, dateTimeP, doubleP, integerP)
 import Toml.PrefixTree (Key (..), Piece (..), fromList)
 import Toml.Type (AnyValue (..), TOML (..), UValue (..), Value (..))
@@ -192,68 +192,30 @@ integerSpecs = describe "integerP" $ do
             parseInteger "0xaBcDeF" 0xaBcDeF
 
 keySpecs :: Spec
-keySpecs = do
-    describe "keyP" $ do
-        context "when the key is a bare key" $ do
-            it "can parse keys which contain ASCII letters, digits, underscores, and dashes" $ do
-                parseKey "key"       (makeKey ["key"])
-                parseKey "bare_key1" (makeKey ["bare_key1"])
-                parseKey "bare-key2" (makeKey ["bare-key2"])
-            it "can parse keys which contain only digits" $
-                parseKey "1234" (makeKey ["1234"])
-        context "when the key is a quoted key" $ do
-            it "can parse keys that follow the exact same rules as basic strings" $ do
-                parseKey (dquote "127.0.0.1") (makeKey [dquote "127.0.0.1"])
-                parseKey (dquote "character encoding") (makeKey [dquote "character encoding"])
-                parseKey (dquote "ʎǝʞ") (makeKey [dquote "ʎǝʞ"])
-            it "can parse keys that follow the exact same rules as literal strings" $ do
-                parseKey (squote "key2") (makeKey [squote "key2"])
-                parseKey (squote "quoted \"value\"") (makeKey [squote "quoted \"value\""])
-        context "when the key is a dotted key" $
-            it "can parse a sequence of bare or quoted keys joined with a dot" $ do
-                parseKey "name"           (makeKey ["name"])
-                parseKey "physical.color" (makeKey ["physical", "color"])
-                parseKey "physical.shape" (makeKey ["physical", "shape"])
-                parseKey "site.\"google.com\"" (makeKey ["site", dquote "google.com"])
-        -- it "ignores whitespaces around dot-separated parts" $
-        --     parseKey "a . b . c. d" (makeKey ["a", "b", "c", "d"])
-
-    describe "hasKeyP" $ do
-        it "can parse key/value pairs" $ do
-            parseHasKey "x='abcdef'" (makeKey ["x"], Left $ AnyValue (Text "abcdef"))
-            parseHasKey "x=1"        (makeKey ["x"], Left $ AnyValue (Integer 1))
-            parseHasKey "x=5.2"      (makeKey ["x"], Left $ AnyValue (Double 5.2))
-            parseHasKey "x=true"     (makeKey ["x"], Left $ AnyValue (Bool True))
-            parseHasKey "x=[1, 2, 3]" (makeKey ["x"] , Left $ AnyValue (Array [Integer 1, Integer 2, Integer 3]))
-            parseHasKey "x = 1920-12-10"
-                (makeKey ["x"], Left $ AnyValue (Day day2))
-        --xit "can parse a key/value pair when the value is an inline table" $ do
-        --  pending
-        it "ignores white spaces around key names and values" $ do
-            parseHasKey "x=1    "   (makeKey ["x"]       , Left $ AnyValue (Integer 1))
-            parseHasKey "x=    1"   (makeKey ["x"]       , Left $ AnyValue (Integer 1))
-            parseHasKey "x    =1"   (makeKey ["x"]       , Left $ AnyValue (Integer 1))
-            parseHasKey "x\t= 1 "   (makeKey ["x"]       , Left $ AnyValue (Integer 1))
-            parseHasKey "\"x\" = 1" (makeKey [dquote "x"], Left $ AnyValue (Integer 1))
-        --xit "fails if the key, equals sign, and value are not on the same line" $ do
-        --  keyValFailOn "x\n=\n1"
-        --  keyValFailOn "x=\n1"
-        --  keyValFailOn "\"x\"\n=\n1"
-        it "works if the value is broken over multiple lines" $
-            parseHasKey "x=[1, \n2\n]" (makeKey ["x"], Left $ AnyValue (Array [Integer 1, Integer 2]))
-        it "fails if the value is not specified" $
-            hasKeyFailOn "x="
-
-        it "can parse a TOML inline table" $
-            parseHasKey "table-1={key1 = \"some string\", key2 = 123}"
-                (makeKey ["table-1"], Right $ tomlFromKeyVal [str, int])
-        it "can parse an empty TOML table" $
-            parseHasKey "table = {}" (makeKey ["table"], Right $ tomlFromKeyVal [])
-        it "allows the name of the table to be any valid TOML key" $ do
-            parseHasKey "dog.\"tater.man\"={}"
-                (makeKey ["dog", dquote "tater.man"], Right $ tomlFromKeyVal [])
-            parseHasKey "j.\"ʞ\".'l'={}"
-                (makeKey ["j", dquote "ʞ", squote "l"], Right $ tomlFromKeyVal [])
+keySpecs = describe "keyP" $ do
+    context "when the key is a bare key" $ do
+        it "can parse keys which contain ASCII letters, digits, underscores, and dashes" $ do
+            parseKey "key"       (makeKey ["key"])
+            parseKey "bare_key1" (makeKey ["bare_key1"])
+            parseKey "bare-key2" (makeKey ["bare-key2"])
+        it "can parse keys which contain only digits" $
+            parseKey "1234" (makeKey ["1234"])
+    context "when the key is a quoted key" $ do
+        it "can parse keys that follow the exact same rules as basic strings" $ do
+            parseKey (dquote "127.0.0.1") (makeKey [dquote "127.0.0.1"])
+            parseKey (dquote "character encoding") (makeKey [dquote "character encoding"])
+            parseKey (dquote "ʎǝʞ") (makeKey [dquote "ʎǝʞ"])
+        it "can parse keys that follow the exact same rules as literal strings" $ do
+            parseKey (squote "key2") (makeKey [squote "key2"])
+            parseKey (squote "quoted \"value\"") (makeKey [squote "quoted \"value\""])
+    context "when the key is a dotted key" $
+        it "can parse a sequence of bare or quoted keys joined with a dot" $ do
+            parseKey "name"           (makeKey ["name"])
+            parseKey "physical.color" (makeKey ["physical", "color"])
+            parseKey "physical.shape" (makeKey ["physical", "shape"])
+            parseKey "site.\"google.com\"" (makeKey ["site", dquote "google.com"])
+    -- it "ignores whitespaces around dot-separated parts" $
+    --     parseKey "a . b . c. d" (makeKey ["a", "b", "c", "d"])
 
 textSpecs :: Spec
 textSpecs = describe "textP" $ do
@@ -392,81 +354,117 @@ dateSpecs = describe "dateTimeP" $ do
         parseDateTime "1979-05-27T00:32:0007:00"
             (ULocal $ LocalTime day1 (TimeOfDay 0 32 0))
 
-tableSpecs :: Spec
-tableSpecs = do
-    describe "tableP" $ do
-        it "can parse a TOML table" $
-          parseTable "key1 = \"some string\"\nkey2 = 123"
-                (tomlFromKeyVal [str, int])
-        it "can parse an empty TOML table" $
-            parseTable "" (tomlFromKeyVal [])
-        it "can parse a table with subarrays" $ do
-            let arr1 = tomlFromArray [(makeKey ["array"], strT :| [intT])]
-            parseTable "[[tablearray]] \nkey1 = \"some string\"\n \
-                        \ [[tablearray]] \nkey2 = 123" arr1
+tomlSpecs :: Spec
+tomlSpecs = do
+    describe "Key/values" $ do
+        it "can parse key/value pairs" $ do
+            parseToml "x='abcdef'" (tomlFromKeyVal [(makeKey ["x"], AnyValue (Text "abcdef"))])
+            parseToml "x=1"        (tomlFromKeyVal [(makeKey ["x"], AnyValue (Integer 1))])
+            parseToml "x=5.2"      (tomlFromKeyVal [(makeKey ["x"], AnyValue (Double 5.2))])
+            parseToml "x=true"     (tomlFromKeyVal [(makeKey ["x"], AnyValue (Bool True))])
+            parseToml "x=[1, 2, 3]" (tomlFromKeyVal [(makeKey ["x"] , AnyValue (Array [Integer 1, Integer 2, Integer 3]))])
+            parseToml "x = 1920-12-10" (tomlFromKeyVal [(makeKey ["x"], AnyValue (Day day2))])
+        it "ignores white spaces around key names and values" $ do
+            let toml = tomlFromKeyVal [(makeKey ["x"], AnyValue (Integer 1))]
+            parseToml "x=1    "   toml
+            parseToml "x=    1"   toml
+            parseToml "x    =1"   toml
+            parseToml "x\t= 1 "   toml
+            parseToml "\"x\" = 1" (tomlFromKeyVal [(makeKey [dquote "x"], AnyValue (Integer 1))])
+        --xit "fails if the key, equals sign, and value are not on the same line" $ do
+        --  keyValFailOn "x\n=\n1"
+        --  keyValFailOn "x=\n1"
+        --  keyValFailOn "\"x\"\n=\n1"
+        it "works if the value is broken over multiple lines" $
+            parseToml "x=[1, \n2\n]" (tomlFromKeyVal [(makeKey ["x"], AnyValue (Array [Integer 1, Integer 2]))])
+        it "fails if the value is not specified" $
+            tomlFailOn "x="
 
-    describe "tableArrayP" $ do
+    describe "tables" $ do
+        it "can parse a TOML table" $
+          parseToml "[table] \n key1 = \"some string\"\nkey2 = 123"
+                $ tomlFromTable [(makeKey ["table"], tomlFromKeyVal [str, int])]
+        it "can parse an empty TOML table" $
+            parseToml "[table]" (tomlFromTable [(makeKey ["table"], mempty)])
+        it "can parse a table with subarrays" $ do
+            let t = tomlFromTable [(makeKey ["table"], tomlFromArray [(makeKey ["array"], strT :| [intT])])]
+            parseToml "[table] \n [[table.array]] \nkey1 = \"some string\"\n \
+                                  \[[table.array]] \nkey2 = 123" t
+        it "can parse a TOML inline table" $
+            parseToml "table={key1 = \"some string\", key2 = 123}"
+                (tomlFromTable [(makeKey ["table"], tomlFromKeyVal [str, int])])
+        it "can parse an empty inline TOML table" $
+            parseToml "table = {}" (tomlFromTable [(makeKey ["table"], mempty)])
+        it "allows the name of the table to be any valid TOML key" $ do
+            parseToml "dog.\"tater.man\"={}"
+                (tomlFromTable [(makeKey ["dog", dquote "tater.man"], mempty)])
+            parseToml "j.\"ʞ\".'l'={}"
+                (tomlFromTable [(makeKey ["j", dquote "ʞ", squote "l"], mempty)])
+
+    describe "array of tables" $ do
         it "can parse an empty array" $
-            parseTableArray "" (mempty :| [])
+            parseToml "[[array]]" (tomlFromArray [(makeKey ["array"], mempty :| [])])
         it "can parse an array of key/values" $ do
-            let array  = NE.fromList [strT, intT]
-            parseTableArray "key1 = \"some string\"\n \
-                            \[[tablearray]]\nkey2 = 123" array
+            let array = tomlFromArray [(makeKey ["array"], NE.fromList [strT, intT])]
+            parseToml "[[array]]\n key1 = \"some string\"\n \
+                      \[[array]]\n key2 = 123" array
         it "can parse an array of tables" $ do
             let table1 = tomlFromTable [(makeKey ["table1"], strT)]
                 table2 = tomlFromTable [(makeKey ["table2"], intT)]
-                array  =  NE.fromList [table1, table2]
-            parseTableArray "[tablearray.table1] \n key1 = \"some string\"\n \
-                            \[[tablearray]]\n[tablearray.table2] \n key2 = 123" array
+                array  = tomlFromArray [(makeKey ["array"], NE.fromList [table1, table2])]
+            parseToml "[[array]]\n[array.table1] \n key1 = \"some string\"\n \
+                      \[[array]]\n[array.table2] \n key2 = 123" array
         it "can parse an array of array" $ do
-            let arr = tomlFromArray [(makeKey ["table-1-1"], NE.fromList [strT, intT])]
-                array = arr :| []
-            parseTableArray "[[tablearray.table-1-1]] \nkey1 = \"some string\"\n \
-                            \[[tablearray.table-1-1]] \nkey2 = 123" array
+            let arr = tomlFromArray [(makeKey ["subarray"], NE.fromList [strT, intT])]
+                array = tomlFromArray [(makeKey ["array"], arr :| [])]
+            parseToml "[[array]] \n [[array.subarray]] \nkey1 = \"some string\"\n \
+                      \[[array.subarray]] \nkey2 = 123" array
         it "can parse an array of arrays" $ do
-            let arr1 = (makeKey ["table-1-1"], strT :| [])
-                arr2 = (makeKey ["table-1-2"], intT :| [])
-                array = tomlFromArray [arr1, arr2] :| []
-            parseTableArray "[[tablearray.table-1-1]] \nkey1 = \"some string\"\n \
-                            \[[tablearray.table-1-2]] \nkey2 = 123" array
+            let arr1 = (makeKey ["table-1"], strT :| [])
+                arr2 = (makeKey ["table-2"], intT :| [])
+                array = tomlFromArray [(makeKey ["array"], tomlFromArray [arr1, arr2] :| [])]
+            parseToml "[[array]]\n [[array.table-1]] \nkey1 = \"some string\"\n \
+                                  \[[array.table-2]] \nkey2 = 123" array
+        it "can parse very large arrays" $ do
+            let array = tomlFromArray [(makeKey ["array"], NE.fromList $ replicate 1000 mempty)]
+            parseToml (mconcat $ replicate 1000 "[[array]]\n") array
 
-tomlSpecs :: Spec
-tomlSpecs = describe "tomlP" $ do
-    it "can parse TOML files" $
-       parseToml tomlStr1 toml1
-    it "can parse mix of tables and arrays" $
-       parseToml tomlStr2 toml2
-  where
-    tomlStr1, tomlStr2 :: Text
-    tomlStr1 = T.unlines
-        [ " # This is a TOML document.\n\n"
-        , "title = \"TOML Example\" # Comment \n\n"
-        , "[owner]\n"
-        , "  name = \"Tom Preston-Werner\" "
-        , "  enabled = true # First class dates"
-        ]
-    tomlStr2 = T.unlines
-        [ "[[array1]]\n key1 = \"some string\" \n"
-        , ""
-        , "[table1]  \n key2 = 123 \n"
-        , "[[array2]]\n key3 = 3.14 \n"
-        , "  [table2]  \n key4 = true"
-        ]
+    describe "TOML" $ do
+        it "can parse TOML files" $
+           parseToml tomlStr1 toml1
+        it "can parse mix of tables and arrays" $
+           parseToml tomlStr2 toml2
+      where
+        tomlStr1, tomlStr2 :: Text
+        tomlStr1 = T.unlines
+            [ " # This is a TOML document.\n\n"
+            , "title = \"TOML Example\" # Comment \n\n"
+            , "[owner]\n"
+            , "  name = \"Tom Preston-Werner\" "
+            , "  enabled = true # First class dates"
+            ]
+        tomlStr2 = T.unlines
+            [ "[[array1]]\n key1 = \"some string\" \n"
+            , ""
+            , "[table1]  \n key2 = 123 \n"
+            , "[[array2]]\n key3 = 3.14 \n"
+            , "  [table2]  \n key4 = true"
+            ]
 
-    toml1, toml2 :: TOML
-    toml1 = mkToml $ do
-        "title" =: "TOML Example"
-        table "owner" $ do
-            "name" =: "Tom Preston-Werner"
-            "enabled" =: Bool True
+        toml1, toml2 :: TOML
+        toml1 = mkToml $ do
+            "title" =: "TOML Example"
+            table "owner" $ do
+                "name" =: "Tom Preston-Werner"
+                "enabled" =: Bool True
 
-    toml2 = mkToml $ do
-        tableArray "array1" $
-            "key1" =: "some string" :| []
-        table "table1" $ "key2" =: 123
-        tableArray "array2" $
-            "key3" =: Double 3.14 :| []
-        table "table2" $ "key4" =: Bool True
+        toml2 = mkToml $ do
+            tableArray "array1" $
+                "key1" =: "some string" :| []
+            table "table1" $ "key2" =: 123
+            tableArray "array2" $
+                "key3" =: Double 3.14 :| []
+            table "table2" $ "key4" =: Bool True
 
 ----------------------------------------------------------------------------
 -- Utilities
@@ -491,25 +489,20 @@ parseInteger :: Text -> Integer -> Expectation
 parseInteger = parseX integerP
 parseKey :: Text -> Key -> Expectation
 parseKey = parseX keyP
-parseHasKey :: Text -> (Key, Either AnyValue TOML) -> Expectation
-parseHasKey = parseX hasKeyP
 parseText :: Text -> Text -> Expectation
 parseText = parseX textP
-parseTable :: Text -> TOML -> Expectation
-parseTable = parseX (tableP (Just "table"))
-parseTableArray :: Text -> NonEmpty TOML -> Expectation
-parseTableArray = parseX (tableArrayP "tablearray")
+
 parseToml :: Text -> TOML -> Expectation
 parseToml = parseX tomlP
 
-arrayFailOn, boolFailOn, dateTimeFailOn, doubleFailOn, hasKeyFailOn, integerFailOn, textFailOn :: Text -> Expectation
+arrayFailOn, boolFailOn, dateTimeFailOn, doubleFailOn, integerFailOn, textFailOn, tomlFailOn :: Text -> Expectation
 arrayFailOn     = failOn arrayP
 boolFailOn      = failOn boolP
 dateTimeFailOn  = failOn dateTimeP
 doubleFailOn    = failOn doubleP
-hasKeyFailOn    = failOn hasKeyP
 integerFailOn   = failOn integerP
 textFailOn      = failOn textP
+tomlFailOn      = failOn tomlP
 
 -- UValue Util
 

--- a/test/Test/Toml/Property.hs
+++ b/test/Test/Toml/Property.hs
@@ -31,7 +31,7 @@ x <> mempty = x
 @
 
 -}
-identityLaw :: (Eq a, Show a, Semigroup a, Monoid a) => Gen a -> PropertyTest
+identityLaw :: (Eq a, Show a, Monoid a) => Gen a -> PropertyTest
 identityLaw gen = prop "Monoid identity laws" $ do
     x <- forAll gen
 

--- a/test/Test/Toml/Property.hs
+++ b/test/Test/Toml/Property.hs
@@ -31,7 +31,7 @@ x <> mempty = x
 @
 
 -}
-identityLaw :: (Eq a, Show a, Monoid a) => Gen a -> PropertyTest
+identityLaw :: (Eq a, Show a, Semigroup a, Monoid a) => Gen a -> PropertyTest
 identityLaw gen = prop "Monoid identity laws" $ do
     x <- forAll gen
 


### PR DESCRIPTION
Fixed the exponential behavior, I've had to change a bunch of functions, but in the end it let me refactor `tomlP` nicely so I think it's worth it. Benchmarking also improved.

Since some signatures changed, I've had to modify some tests.

I've also added an `eof` to the TOML parser to make sure the whole `.toml` file is valid.

Benchmarks:
Without fix:
```
benchmarked Parse/tomland
time                 440.8 μs   (430.0 μs .. 453.9 μs)
                     0.993 R²   (0.989 R² .. 0.997 R²)
mean                 433.0 μs   (427.9 μs .. 440.4 μs)
std dev              20.27 μs   (14.42 μs .. 31.25 μs)
variance introduced by outliers: 27% (moderately inflated)
```

With fix:
```
benchmarked Parse/tomland
time                 355.8 μs   (348.9 μs .. 368.5 μs)
                     0.990 R²   (0.980 R² .. 0.998 R²)
mean                 360.6 μs   (356.1 μs .. 368.5 μs)
std dev              19.44 μs   (13.67 μs .. 27.89 μs)
variance introduced by outliers: 32% (moderately inflated)
```
That's a 15% speedup.

