### PR TITLE
Prepare 1.1.0.0 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,47 @@
 tomland uses [PVP Versioning][1].
 The changelog is available [on GitHub][2].
 
+## 1.1.0.0 — Jul 8, 2019
+
+* [#154](https://github.com/kowainik/tomland/issues/154):
+  Implement `Generic` bidirectional codecs
+  (by [@chshersh](https://github.com/chshersh)).
+* [#145](https://github.com/kowainik/tomland/issues/145):
+  Add support for inline table arrays
+  (by [@jiegillet](https://github.com/jiegillet)).
+* [#195](https://github.com/kowainik/tomland/issues/195):
+  Fix an exponential parser behavior for parsing table of arrays
+  (by [@jiegillet](https://github.com/jiegillet)).
+* [#190](https://github.com/kowainik/tomland/issues/190):
+  Add `enumBounded` codec for nullary sum types
+  (by [@mxxo](https://github.com/mxxo)).
+* [#189](https://github.com/kowainik/tomland/issues/189):
+  **Breaking change:** Implement custom table sorting by keys. Also fields of
+  the `PrintOptions` data type were renamed according to style guide
+  (by [@ramanshah](https://github.com/ramanshah)).
+
+  __Before:__
+
+  ```haskell
+  data PrintOptions = PrintOptions
+      { shouldSort :: Bool
+      , indent     :: Int
+      } deriving (Show)
+  ```
+
+  __Now:__
+
+  ```haskell
+  data PrintOptions = PrintOptions
+      { printOptionsSorting :: !(Maybe (Key -> Key -> Ordering))
+      , printOptionsIndent  :: !Int
+      }
+  ```
+
+  __Migration guide:__ If you used `indent` field, use `printOptionsIndent`
+  instead. If you used `shouldSort`, use `printOptionsSorting` instead and pass
+  `Nothing` instead of `False` or `Just compare` instead of `True`.
+
 ## 1.0.1.0 — May 17, 2019
 
 * [#177](https://github.com/kowainik/tomland/issues/177):
@@ -10,10 +51,6 @@ The changelog is available [on GitHub][2].
 * [#187](https://github.com/kowainik/tomland/issues/187):
   Bump up to `hedgehog-1.0`.
 * Support GHC 8.6.5
-* [#195](https://github.com/kowainik/tomland/issues/195):
-  Fixed an exponential behavior for parsing nested table of arrays.
-* [#145](https://github.com/kowainik/tomland/issues/145):
-  Parser and tests for inline arrays of tables.
 
 ## 1.0.0 — Jan 14, 2019
 

--- a/src/Toml/Bi/Combinators.hs
+++ b/src/Toml/Bi/Combinators.hs
@@ -164,8 +164,12 @@ string = match _String
 read :: (Show a, Read a) => Key -> TomlCodec a
 read = match _Read
 
--- | Codec for general nullary sum data types with a 'Bounded', 'Enum', and 'Show'
--- instance. This codec provides much better error messages than 'read' for nullary sum types.
+{- | Codec for general nullary sum data types with a 'Bounded', 'Enum', and
+'Show' instance. This codec provides much better error messages than 'read' for
+nullary sum types.
+
+@since 1.1.1.0
+-}
 enumBounded :: (Bounded a, Enum a, Show a) => Key -> TomlCodec a
 enumBounded = match _EnumBounded
 

--- a/src/Toml/Bi/Map.hs
+++ b/src/Toml/Bi/Map.hs
@@ -384,7 +384,10 @@ _BoundedInteger = BiMap (Right . toInteger) eitherBounded
          in Left $ ArbitraryError msg
       | otherwise = Right (fromIntegral n)
 
--- | Helper bimap for 'EnumBounded' and 'Data.Text.Text'.
+{- | Helper bimap for 'EnumBounded' and 'Data.Text.Text'.
+
+@since 1.1.1.0
+-}
 _EnumBoundedText :: forall a. (Show a, Enum a, Bounded a) => TomlBiMap a Text
 _EnumBoundedText = BiMap
     { forward  = Right . tShow
@@ -403,8 +406,11 @@ _EnumBoundedText = BiMap
         options  = fmap tShow enums
         enums = [minBound @a .. maxBound @a]
 
--- | Bimap for nullary sum data types with 'Show', 'Enum' and 'Bounded'
--- instances.  Usually used as 'Toml.Bi.Combinators.enumBounded' combinator.
+{- | Bimap for nullary sum data types with 'Show', 'Enum' and 'Bounded'
+instances.  Usually used as 'Toml.Bi.Combinators.enumBounded' combinator.
+
+@since 1.1.1.0
+-}
 _EnumBounded :: (Show a, Enum a, Bounded a) => TomlBiMap a AnyValue
 _EnumBounded = _EnumBoundedText >>> _Text
 
@@ -489,7 +495,7 @@ _HashSet :: (Eq a, Hashable a) => TomlBiMap a AnyValue -> TomlBiMap (HS.HashSet 
 _HashSet bi = iso HS.toList HS.fromList >>> _Array bi
 
 {- | 'IS.IntSet' bimap for 'AnyValue'. Usually used as
-'Toml.Bi.Combinators.arrayIntSetOf' combinator.
+'Toml.Bi.Combinators.arrayIntSet' combinator.
 -}
 _IntSet :: TomlBiMap IS.IntSet AnyValue
 _IntSet = iso IS.toList IS.fromList >>> _Array _Int

--- a/src/Toml/Generic.hs
+++ b/src/Toml/Generic.hs
@@ -59,7 +59,7 @@ userCodec :: 'TomlCodec' User
 userCodec = User
     \<$\> Toml.int "age" .= age
     \<*\> Toml.table addressCodec "address" .= address
-    \<*\> Toml.list  socialCodec "socials"  .= socials
+    \<*\> Toml.list  socialCodec  "socials" .= socials
 
 addressCodec :: 'TomlCodec' Address
 addressCodec = Address
@@ -94,6 +94,8 @@ generic codecs).
 the instance of the 'HasCodec' typeclass.
 3. If the data type appears as an element of a list, you need to implement the instance
 of the 'HasItemCodec' typeclass.
+
+@since 1.1.1.0
 -}
 
 module Toml.Generic

--- a/src/Toml/Printer.hs
+++ b/src/Toml/Printer.hs
@@ -28,9 +28,14 @@ import qualified Data.Text as Text
 
 {- | Configures the pretty printer. -}
 data PrintOptions = PrintOptions
-    { -- | How table keys should be sorted, if at all.
+    { {- | How table keys should be sorted, if at all.
+
+      @since 1.1.1.0
+      -}
       printOptionsSorting :: !(Maybe (Key -> Key -> Ordering))
-      -- | Number of spaces by which to indent.
+
+      {- | Number of spaces by which to indent.
+      -}
     , printOptionsIndent  :: !Int
     }
 

--- a/tomland.cabal
+++ b/tomland.cabal
@@ -1,6 +1,6 @@
 cabal-version:       2.4
 name:                tomland
-version:             1.0.1.0
+version:             1.1.0.0
 synopsis:            Bidirectional TOML serialization
 description:
     Implementation of bidirectional TOML serialization. Simple codecs look like this:


### PR DESCRIPTION
* Bump version to `1.1.0.0` (due to breaking change)
* Add `@since` annotations to new functions
* Write CHANGELOG for the `1.1.0.0` version