### PR TITLE
[#209] Bump up parser-combinators to 1.2.0

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -24,6 +24,7 @@ cabal.project.local
 
 # Stack
 .stack-work/
+stack.yaml.lock
 
 ### IDE/support
 # Vim

--- a/stack.yaml
+++ b/stack.yaml
@@ -2,7 +2,7 @@ resolver: lts-13.25
 
 extra-deps:
   - hedgehog-1.0
-  - parser-combinators-1.1.0
+  - parser-combinators-1.2.0
   - tasty-hedgehog-1.0.0.0
   - toml-parser-0.1.0.0
 

--- a/tomland.cabal
+++ b/tomland.cabal
@@ -95,7 +95,7 @@ library
                      , hashable ^>= 1.2
                      , megaparsec ^>= 7.0.5
                      , mtl ^>= 2.2
-                     , parser-combinators ^>= 1.1.0
+                     , parser-combinators >= 1.1.0 && < 1.3
                      , text ^>= 1.2
                      , time >= 1.8 && < 1.10
                      , transformers ^>= 0.5


### PR DESCRIPTION
Resolves #209
We can just make a revision on Hackage for this.