### PR TITLE
Cleanup some metadata

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -46,7 +46,7 @@ script:
     if [ -z "$STACK_YAML" ]; then
       cabal test --enable-tests
     else
-      stack test --no-terminal
+      stack test --no-terminal --system-ghc
     fi
 
 notifications:

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,7 @@ language: haskell
 git:
   depth: 5
 
-cabal: "head"
+cabal: "3.0"
 
 cache:
   directories:

--- a/src/Toml/Parser/Key.hs
+++ b/src/Toml/Parser/Key.hs
@@ -46,4 +46,4 @@ tableNameP = between (text "[") (text "]") keyP <* sc
 
 -- | Parser for array of tables name: 'Key' inside @[[]]@.
 tableArrayNameP :: Parser Key
-tableArrayNameP = between (text "[[") (text "]]") keyP
+tableArrayNameP = between (text "[[") (text "]]") keyP <* sc

--- a/tomland.cabal
+++ b/tomland.cabal
@@ -1,6 +1,6 @@
 cabal-version:       2.4
 name:                tomland
-version:             1.1.0.1
+version:             1.2.0.0
 synopsis:            Bidirectional TOML serialization
 description:
     Implementation of bidirectional TOML serialization. Simple codecs look like this:
@@ -33,7 +33,7 @@ build-type:          Simple
 extra-doc-files:     README.md
                      CHANGELOG.md
 extra-source-files:  test/golden/*.golden
-                   , test/examples/*.toml
+                     test/examples/*.toml
 tested-with:         GHC == 8.2.2
                      GHC == 8.4.4
                      GHC == 8.6.5
@@ -57,6 +57,7 @@ common common-options
                        -freverse-errors
   if impl(ghc >= 8.8.1)
     ghc-options:       -Wmissing-deriving-strategies
+                       -Werror=missing-deriving-strategies
 
   default-language:    Haskell2010
   default-extensions:  DeriveGeneric


### PR DESCRIPTION
Cleanup some metadata:

1. Use `--system-ghc` for `stack` builds.
2. Missing deriving strategies now produce a compiletime error to make sure they are used.