### PR TITLE
Avoid to generate text with ending backslash

### DIFF
--- a/test/Test/Toml/Gen.hs
+++ b/test/Test/Toml/Gen.hs
@@ -102,7 +102,7 @@ genVal :: MonadGen m => m V
 genVal = Gen.int (Range.constant 0 256)
 
 -- | Generates random value of 'AnyValue' type.
-genAnyValue :: MonadGen m => m AnyValue
+genAnyValue :: (MonadGen m, GenBase m ~ Identity) => m AnyValue
 genAnyValue = Gen.choice $
     (AnyValue <$> genArray) : noneArrayList
 
@@ -126,7 +126,7 @@ genPiece = Piece <$> Gen.choice [bare, quoted]
     quotedWith c = wrapChar c <$> Gen.text (Range.constant 1 10) (Gen.filter (/= c) notControl)
 
     quoted :: m Text
-    quoted = Gen.choice [quotedWith '"', quotedWith '\'']
+    quoted = Gen.filter invalidEscape $ Gen.choice [quotedWith '"', quotedWith '\'']
 
 genKey :: (MonadGen m, GenBase m ~ Identity) => m Key
 genKey = Key <$> Gen.nonEmpty (Range.constant 1 10) genPiece
@@ -285,8 +285,8 @@ genUniHex8Color = do
     pure . Text.pack $ "\\U" ++ hex
 
 -- | Generates text from different symbols.
-genText :: MonadGen m => m Text
-genText =  fmap Text.concat $ Gen.list (Range.constant 0 256) $ Gen.choice
+genText :: (MonadGen m, GenBase m ~ Identity) => m Text
+genText = Gen.filter invalidEscape $ fmap Text.concat $ Gen.list (Range.constant 0 256) $ Gen.choice
     [ Text.singleton <$> Gen.alphaNum
     , genEscapeSequence
     , genPunctuation
@@ -307,7 +307,7 @@ genLText :: Gen L.Text
 genLText = L.fromStrict <$> genText
 
 -- | List of AnyValue generators.
-noneArrayList :: MonadGen m => [m AnyValue]
+noneArrayList :: (MonadGen m, GenBase m ~ Identity) => [m AnyValue]
 noneArrayList =
     [ AnyValue . Bool    <$> genBool
     , AnyValue . Integer <$> genInteger
@@ -332,7 +332,15 @@ Array [Double (-563397.0197456297),Double (-308866.62837749254),Double (-29555.3
 Nested array of AnyValue:
 Array [Array [Text "ACyz38VcLz0hxwdFkHTU6PYK8h8CeaiEpI2xAaiZTKBQ3zC1W717cZY35lk8EAK6pPw3WvwIdNktxIV2LrvFSpU8ee6zkXvpvePitW9aspAeeOCF9Q9ry20y7skFZ2qShi7CSx8888zWIqyc8iBkoLNvq4fONLtuUqSw2SlNee4hDIwrnx5O4RuHW1dQfJcnC34h9S0DlIGYP08qq6QHxO4E0HE74cNmiViGm3xpDC8Ro5D8Y6p0FLSN1ELq9Lwm",Text "HhNv0LKICdlKxN"],Array [Integer 986479839551009895,Integer 8636972066308796678,Integer (-3464941350081979804),Integer (-6560688879547055621),Integer (-4749037439349044738)],Array []]
 -}
-genArray :: MonadGen m => m (Value 'TArray)
+genArray :: (MonadGen m, GenBase m ~ Identity) => m (Value 'TArray)
 genArray = Gen.recursive Gen.choice
     [Gen.choice $ map genArrayFrom noneArrayList]
     [Array <$> Gen.list (Range.constant 0 5) genArray]
+
+-- filters
+
+invalidEscape :: Text -> Bool
+invalidEscape t
+    | t == Text.empty = True
+    | Text.last t == '\\' = False
+    | otherwise = True

--- a/test/Test/Toml/Gen.hs
+++ b/test/Test/Toml/Gen.hs
@@ -3,7 +3,6 @@
 {-# LANGUAGE ScopedTypeVariables #-}
 {-# LANGUAGE TypeApplications    #-}
 {-# LANGUAGE TypeFamilies        #-}
-{-# LANGUAGE OverloadedStrings   #-}
 
 -- | This module contains all generators for @tomland@ testing.
 

--- a/test/Test/Toml/Gen.hs
+++ b/test/Test/Toml/Gen.hs
@@ -3,6 +3,7 @@
 {-# LANGUAGE ScopedTypeVariables #-}
 {-# LANGUAGE TypeApplications    #-}
 {-# LANGUAGE TypeFamilies        #-}
+{-# LANGUAGE OverloadedStrings   #-}
 
 -- | This module contains all generators for @tomland@ testing.
 
@@ -113,8 +114,8 @@ genPiece = Piece <$> Gen.choice [bare, quoted]
     alphadashes :: m Char
     alphadashes = Gen.choice [Gen.alphaNum, Gen.element "_-"]
 
-    notControl :: m Char
-    notControl = Gen.filter (not . Char.isControl) Gen.unicode
+    validChar :: m Char
+    validChar = Gen.filter (not . Char.isControl) Gen.unicode
 
     bare :: m Text
     bare = Gen.text (Range.constant 1 10) alphadashes
@@ -123,10 +124,10 @@ genPiece = Piece <$> Gen.choice [bare, quoted]
     wrapChar c = Text.cons c . (`Text.append` Text.singleton c)
 
     quotedWith :: Char -> m Text
-    quotedWith c = wrapChar c <$> Gen.text (Range.constant 1 10) (Gen.filter (/= c) notControl)
+    quotedWith c = wrapChar c <$> Gen.text (Range.constant 1 10) (Gen.filter (/= c) validChar)
 
     quoted :: m Text
-    quoted = Gen.filter invalidEscape $ Gen.choice [quotedWith '"', quotedWith '\'']
+    quoted = Gen.filter validText $ Gen.choice [quotedWith '"', quotedWith '\'']
 
 genKey :: (MonadGen m, GenBase m ~ Identity) => m Key
 genKey = Key <$> Gen.nonEmpty (Range.constant 1 10) genPiece
@@ -286,7 +287,7 @@ genUniHex8Color = do
 
 -- | Generates text from different symbols.
 genText :: (MonadGen m, GenBase m ~ Identity) => m Text
-genText = Gen.filter invalidEscape $ fmap Text.concat $ Gen.list (Range.constant 0 256) $ Gen.choice
+genText = Gen.filter validText $ fmap Text.concat $ Gen.list (Range.constant 0 256) $ Gen.choice
     [ Text.singleton <$> Gen.alphaNum
     , genEscapeSequence
     , genPunctuation
@@ -339,8 +340,20 @@ genArray = Gen.recursive Gen.choice
 
 -- filters
 
-invalidEscape :: Text -> Bool
-invalidEscape t
-    | t == Text.empty = True
-    | Text.last t == '\\' = False
-    | otherwise = True
+-- | True if Text is valid based on TOML syntax (https://github.com/toml-lang/toml#string)
+validText :: Text -> Bool
+validText = validString . Text.unpack
+  where
+    validString :: String -> Bool
+    validString [] = True
+    validString ['\\'] = False
+    validString ('\\':'b':s) = validString s
+    validString ('\\':'t':s) = validString s
+    validString ('\\':'n':s) = validString s
+    validString ('\\':'f':s) = validString s
+    validString ('\\':'r':s) = validString s
+    validString ('\\':'"':s) = validString s
+    validString ('\\':'\'':t) = validString t
+    validString ('\\':'u':n1:n2:n3:n4:t) = (all Char.isHexDigit [n1, n2, n3, n4]) && validString t
+    validString ('\\':'U':n1:n2:n3:n4:n5:n6:n7:n8:t) = (all Char.isHexDigit [n1, n2, n3, n4, n5, n6, n7, n8]) && validString t
+    validString (_:t) = validString t

--- a/test/Test/Toml/Gen.hs
+++ b/test/Test/Toml/Gen.hs
@@ -353,6 +353,7 @@ validText = validString . Text.unpack
     validString ('\\':'r':s) = validString s
     validString ('\\':'"':s) = validString s
     validString ('\\':'\'':t) = validString t
+    validString ('\\':'\\':t) = validString t
     validString ('\\':'u':n1:n2:n3:n4:t) = (all Char.isHexDigit [n1, n2, n3, n4]) && validString t
     validString ('\\':'U':n1:n2:n3:n4:n5:n6:n7:n8:t) = (all Char.isHexDigit [n1, n2, n3, n4, n5, n6, n7, n8]) && validString t
     validString (_:t) = validString t


### PR DESCRIPTION
Fixes half of #198 

We were wondering why you didn't use `genPrefixMap` in `genToml`, seems like the second problem stated in #198 it might be related to `genPrefixMap`, are we on the right path?

Proudly made by @sphaso and @gabrielelana at "Open Source Saturday Milano"

[![Open Source Saturday](https://img.shields.io/badge/%E2%9D%A4%EF%B8%8F-open%20source%20saturday-F64060.svg)](https://www.meetup.com/it-IT/Open-Source-Saturday-Milano/)