### PR TITLE
[#227] Proper newline handling in parser

### DIFF
--- a/src/Toml/Parser/Key.hs
+++ b/src/Toml/Parser/Key.hs
@@ -13,7 +13,7 @@ import Control.Monad.Combinators (between)
 import Data.Semigroup ((<>))
 import Data.Text (Text)
 
-import Toml.Parser.Core (Parser, alphaNumChar, char, lexeme, sc, text)
+import Toml.Parser.Core (Parser, alphaNumChar, char, lexeme, text)
 import Toml.Parser.String (basicStringP, literalStringP)
 import Toml.PrefixTree (Key (..), Piece (..))
 
@@ -42,8 +42,8 @@ keyP = Key <$> keyComponentP `sepBy1` char '.'
 
 -- | Parser for table name: 'Key' inside @[]@.
 tableNameP :: Parser Key
-tableNameP = between (text "[") (text "]") keyP <* sc
+tableNameP = between (text "[") (text "]") keyP
 
 -- | Parser for array of tables name: 'Key' inside @[[]]@.
 tableArrayNameP :: Parser Key
-tableArrayNameP = between (text "[[") (text "]]") keyP <* sc
+tableArrayNameP = between (text "[[") (text "]]") keyP


### PR DESCRIPTION
Resolves #227

There actually was no problems in the first place! The problem was in a problematic generator in tests (which should be fixed now). The following string for examples parses perfectly:

```haskell
"\n[[a]]\n  \"x\" = []\n"
```

So I just removed redundant code I introduced earlier.