### PR TITLE
[#217] Use TOML Edsl, remove redundant utility functions in tests

### DIFF
--- a/test/Test/Toml/Parsing/Unit/Common.hs
+++ b/test/Test/Toml/Parsing/Unit/Common.hs
@@ -1,8 +1,42 @@
 {-# LANGUAGE FlexibleContexts #-}
 
-module Test.Toml.Parsing.Unit.Common where
+module Test.Toml.Parsing.Unit.Common
+       ( parseX
+       , failOn
+       , parseArray
+       , parseBool
+       , parseDouble
+       , parseInteger
+       , parseKey
+       , parseText
+       , parseToml
+       , parseDateTime
+       , arrayFailOn
+       , boolFailOn
+       , integerFailOn
+       , dateTimeFailOn
+       , doubleFailOn
+       , textFailOn
+       , tomlFailOn
+       , quoteWith
+       , squote
+       , dquote
+       , squote3
+       , dquote3
+       , makeKey
+       , makeOffset
+       , makeZoned
+       , int1
+       , int2
+       , int3
+       , int4
+       , offset710
+       , offset0
+       , day1
+       , day2
+       , hours1
+       ) where
 
-import Data.List.NonEmpty (NonEmpty (..))
 import Data.Semigroup ((<>))
 import Data.Text (Text)
 import Data.Time (Day, LocalTime (..), TimeOfDay (..), TimeZone, ZonedTime (..), fromGregorian,
@@ -16,10 +50,9 @@ import Toml.Parser.Key (keyP)
 import Toml.Parser.String (textP)
 import Toml.Parser.Validate (validateItems)
 import Toml.Parser.Value (arrayP, boolP, dateTimeP, doubleP, integerP)
-import Toml.PrefixTree (Key (..), Piece (..), fromList)
-import Toml.Type (AnyValue (..), TOML (..), UValue (..), Value (..))
+import Toml.PrefixTree (Key (..), Piece (..))
+import Toml.Type (TOML (..), UValue (..))
 
-import qualified Data.HashMap.Lazy as HashMap
 import qualified Data.List.NonEmpty as NE
 
 ----------------------------------------------------------------------------
@@ -93,25 +126,7 @@ makeOffset hours mins = minutesToTimeZone (hours * 60 + mins * signum hours)
 makeKey :: [Text] -> Key
 makeKey = Key . NE.fromList . map Piece
 
-tomlFromKeyVal :: [(Key, AnyValue)] -> TOML
-tomlFromKeyVal kv = TOML (HashMap.fromList kv) mempty mempty
-
-tomlFromTable :: [(Key, TOML)] -> TOML
-tomlFromTable t = TOML mempty (fromList t) mempty
-
-tomlFromArray :: [(Key, NonEmpty TOML)] -> TOML
-tomlFromArray = TOML mempty mempty . HashMap.fromList
-
 -- Test Data
-
--- Key-Value pairs
-str, int :: (Key, AnyValue)
-str = (makeKey ["key1"], AnyValue (Text "some string"))
-int = (makeKey ["key2"], AnyValue (Integer 123))
-
-strT, intT :: TOML
-strT = tomlFromKeyVal [str]
-intT = tomlFromKeyVal [int]
 
 int1, int2, int3, int4 :: UValue
 int1 = UInteger 1

--- a/test/Test/Toml/Parsing/Unit/Common.hs
+++ b/test/Test/Toml/Parsing/Unit/Common.hs
@@ -23,7 +23,6 @@ module Test.Toml.Parsing.Unit.Common
        , dquote
        , squote3
        , dquote3
-       , makeKey
        , makeOffset
        , makeZoned
        , int1
@@ -50,10 +49,8 @@ import Toml.Parser.Key (keyP)
 import Toml.Parser.String (textP)
 import Toml.Parser.Validate (validateItems)
 import Toml.Parser.Value (arrayP, boolP, dateTimeP, doubleP, integerP)
-import Toml.PrefixTree (Key (..), Piece (..))
+import Toml.PrefixTree (Key (..))
 import Toml.Type (TOML (..), UValue (..))
-
-import qualified Data.List.NonEmpty as NE
 
 ----------------------------------------------------------------------------
 -- Utilities
@@ -122,9 +119,6 @@ makeZoned d h offset = UZoned $ ZonedTime (LocalTime d h) offset
 
 makeOffset :: Int -> Int -> TimeZone
 makeOffset hours mins = minutesToTimeZone (hours * 60 + mins * signum hours)
-
-makeKey :: [Text] -> Key
-makeKey = Key . NE.fromList . map Piece
 
 -- Test Data
 

--- a/test/Test/Toml/Parsing/Unit/Key.hs
+++ b/test/Test/Toml/Parsing/Unit/Key.hs
@@ -1,33 +1,35 @@
 {-# LANGUAGE FlexibleContexts #-}
+{-# LANGUAGE PatternSynonyms  #-}
 
 module Test.Toml.Parsing.Unit.Key where
 
 import Test.Tasty.Hspec (Spec, context, describe, it)
+import Toml.PrefixTree (pattern (:||))
 
-import Test.Toml.Parsing.Unit.Common
+import Test.Toml.Parsing.Unit.Common (dquote, parseKey, squote)
 
 keySpecs :: Spec
 keySpecs = describe "keyP" $ do
     context "when the key is a bare key" $ do
         it "can parse keys which contain ASCII letters, digits, underscores, and dashes" $ do
-            parseKey "key"       (makeKey ["key"])
-            parseKey "bare_key1" (makeKey ["bare_key1"])
-            parseKey "bare-key2" (makeKey ["bare-key2"])
+            parseKey "key"       "key"
+            parseKey "bare_key1" "bare_key1"
+            parseKey "bare-key2" "bare-key2"
         it "can parse keys which contain only digits" $
-            parseKey "1234" (makeKey ["1234"])
+            parseKey "1234" "1234"
     context "when the key is a quoted key" $ do
         it "can parse keys that follow the exact same rules as basic strings" $ do
-            parseKey (dquote "127.0.0.1") (makeKey [dquote "127.0.0.1"])
-            parseKey (dquote "character encoding") (makeKey [dquote "character encoding"])
-            parseKey (dquote "ʎǝʞ") (makeKey [dquote "ʎǝʞ"])
+            parseKey (dquote "127.0.0.1") ("\"127.0.0.1\"" :|| [])
+            parseKey (dquote "character encoding") "\"character encoding\""
+            parseKey (dquote "ʎǝʞ") "\"ʎǝʞ\""
         it "can parse keys that follow the exact same rules as literal strings" $ do
-            parseKey (squote "key2") (makeKey [squote "key2"])
-            parseKey (squote "quoted \"value\"") (makeKey [squote "quoted \"value\""])
+            parseKey (squote "key2") "'key2'"
+            parseKey (squote "quoted \"value\"") "'quoted \"value\"'"
     context "when the key is a dotted key" $ do
         it "can parse a sequence of bare or quoted keys joined with a dot" $ do
-            parseKey "name"           (makeKey ["name"])
-            parseKey "physical.color" (makeKey ["physical", "color"])
-            parseKey "physical.shape" (makeKey ["physical", "shape"])
-            parseKey "site.\"google.com\"" (makeKey ["site", dquote "google.com"])
+            parseKey "name"           "name"
+            parseKey "physical.color" "physical.color"
+            parseKey "physical.shape" "physical.shape"
+            parseKey "site.\"google.com\"" ("site" :|| ["\"google.com\""])
         -- it "ignores whitespaces around dot-separated parts" $ do
         --     parseKey "a . b . c. d" (makeKey ["a", "b", "c", "d"])

--- a/test/Test/Toml/Parsing/Unit/Toml.hs
+++ b/test/Test/Toml/Parsing/Unit/Toml.hs
@@ -22,25 +22,25 @@ tomlSpecs :: Spec
 tomlSpecs = do
     describe "Key/values" $ do
         it "can parse key/value pairs" $ do
-            parseToml "x = 'abcdef'" $ mkToml ("x" =: Text "abcdef")
-            parseToml "x = 1"  $ mkToml ("x" =: Integer 1)
-            parseToml "x = 5.2" $ mkToml ("x" =: Double 5.2)
+            parseToml "x='abcdef'" $ mkToml ("x" =: "abcdef")
+            parseToml "x= 1"  $ mkToml ("x" =: 1)
+            parseToml "x =5.2" $ mkToml ("x" =: Double 5.2)
             parseToml "x = true" $ mkToml ("x" =: Bool True)
-            parseToml "x = [1, 2, 3]" $ mkToml ("x" =: Array [Integer 1, Integer 2, Integer 3])
-            parseToml "x = 1920-12-10" $ mkToml ("x" =: Day day2)
+            parseToml "x= [1, 2, 3]" $ mkToml ("x" =: Array [1, 2, 3])
+            parseToml "x =1920-12-10" $ mkToml ("x" =: Day day2)
         it "ignores white spaces around key names and values" $ do
-            let toml = mkToml ("x" =: Integer 1)
+            let toml = mkToml ("x" =: 1)
             parseToml "x=1    "   toml
             parseToml "x=    1"   toml
             parseToml "x    =1"   toml
             parseToml "x\t= 1 "   toml
-            parseToml "\"x\" = 1" $ mkToml ("\"x\"" =: Integer 1)
+            parseToml "\"x\" = 1" $ mkToml ("\"x\"" =: 1)
         --xit "fails if the key, equals sign, and value are not on the same line" $ do
         --  keyValFailOn "x\n=\n1"
         --  keyValFailOn "x=\n1"
         --  keyValFailOn "\"x\"\n=\n1"
         it "works if the value is broken over multiple lines" $
-            parseToml "x=[1, \n2\n]" $ mkToml ("x" =: Array [Integer 1, Integer 2])
+            parseToml "x=[1, \n2\n]" $ mkToml ("x" =: Array [1, 2])
         it "fails if the value is not specified" $
             tomlFailOn "x="
 
@@ -48,8 +48,8 @@ tomlSpecs = do
         it "can parse a TOML table" $ do
             let t  = mkToml $
                         table "table" $ do
-                            "key1" =: Text "some string"
-                            "key2" =: Integer 123
+                            "key1" =: "some string"
+                            "key2" =: 123
 
             parseToml "[table] \n key1 = \"some string\"\nkey2 = 123" t
         it "can parse an empty TOML table" $
@@ -57,7 +57,7 @@ tomlSpecs = do
         it "can parse a table with subarrays" $ do
             let t = mkToml $
                         table "table" $
-                            tableArray "array" ("key1" =: Text "some string" :| ["key2" =: Integer 123])
+                            tableArray "array" ("key1" =: "some string" :| ["key2" =: 123])
 
             parseToml "[table] \n [[table.array]] \nkey1 = \"some string\"\n \
                                   \[[table.array]] \nkey2 = 123" t
@@ -65,22 +65,22 @@ tomlSpecs = do
             parseToml "table={key1 = \"some string\", key2 = 123}" $
                 mkToml $
                     table "table" $ do
-                        "key1" =: Text "some string"
-                        "key2" =: Integer 123
+                        "key1" =: "some string"
+                        "key2" =: 123
         it "can parse an empty inline TOML table" $
             parseToml "table = {}" $ mkToml (table "table" empty)
         it "can parse a table followed by an inline table" $
             parseToml "[table1] \n  key1 = \"some string\" \n table2 = {key2 = 123}" $
                 mkToml $
                     table "table1" $ do
-                        "key1" =: Text "some string"
-                        table "table2" $ "key2" =: Integer 123
+                        "key1" =: "some string"
+                        table "table2" $ "key2" =: 123
         it "can parse an empty table followed by an inline table" $
             parseToml "[table1] \n table2 = {key2 = 123}" $
                 mkToml $
                     table "table1" $
                         table "table2" $
-                            "key2" =: Integer 123
+                            "key2" =: 123
         it "allows the name of the table to be any valid TOML key" $ do
             parseToml "dog.\"tater.man\"={}" $ mkToml $ table ("dog" :|| ["\"tater.man\""]) empty
             parseToml "j.\"ʞ\".'l'={}" $ mkToml $ table "j.\"ʞ\".'l'" empty
@@ -91,20 +91,20 @@ tomlSpecs = do
         it "can parse an array of key/values" $ do
             let array = mkToml $
                         tableArray "array" $
-                            "key1" =: Text "some string" :|
-                            ["key2" =: Integer 123]
+                            "key1" =: "some string" :|
+                            ["key2" =: 123]
 
             parseToml "[[array]]\n key1 = \"some string\"\n \
                        \[[array]]\n key2 = 123" array
         it "can parse an array of tables" $ do
-            let table1 = table "table1" ("key1" =: Text "some string")
-                table2 = table "table2" ("key2" =: Integer 123)
+            let table1 = table "table1" ("key1" =: "some string")
+                table2 = table "table2" ("key2" =: 123)
                 array = mkToml $ tableArray "array" $ table1 :| [table2]
 
             parseToml "[[array]]\n[array.table1] \n key1 = \"some string\"\n \
                        \[[array]]\n[array.table2] \n key2 = 123" array
         it "can parse an array of array" $ do
-            let arr = tableArray "subarray" ("key1" =: Text "some string" :| ["key2" =: Integer 123])
+            let arr = tableArray "subarray" ("key1" =: "some string" :| ["key2" =: 123])
                 array = mkToml $ tableArray "array" (arr :| [])
 
             parseToml "[[array]] \n [[array.subarray]] \nkey1 = \"some string\"\n \
@@ -122,7 +122,7 @@ tomlSpecs = do
             let array = mkToml $ tableArray "array" $ NE.fromList $ replicate 1000 empty
             parseToml (mconcat $ replicate 1000 "[[array]]\n") array
         it "can parse an inline array of tables" $ do
-            let array = mkToml $ tableArray "table" $ NE.fromList ["key1" =: Text "some string", "key2" =: Integer 123]
+            let array = mkToml $ tableArray "table" $ NE.fromList ["key1" =: "some string", "key2" =: 123]
             parseToml "table = [{key1 = \"some string\"}, {key2 = 123}]" array
 
     describe "TOML" $ do

--- a/test/Test/Toml/Parsing/Unit/Toml.hs
+++ b/test/Test/Toml/Parsing/Unit/Toml.hs
@@ -1,4 +1,5 @@
 {-# LANGUAGE FlexibleContexts #-}
+{-# LANGUAGE PatternSynonyms  #-}
 
 module Test.Toml.Parsing.Unit.Toml where
 
@@ -8,109 +9,120 @@ import Data.Text (Text)
 
 import Test.Tasty.Hspec (Spec, describe, it)
 
-import Toml.Edsl (mkToml, table, tableArray, (=:))
-import Toml.Type (AnyValue (..), TOML (..), Value (..))
+import Toml.Edsl (empty, mkToml, table, tableArray, (=:))
+import Toml.PrefixTree (pattern (:||))
+import Toml.Type (TOML (..), Value (..))
 
 import qualified Data.List.NonEmpty as NE
 import qualified Data.Text as T
 
-import Test.Toml.Parsing.Unit.Common (day2, dquote, int, intT, makeKey, parseToml, squote, str,
-                                      strT, tomlFailOn, tomlFromArray, tomlFromKeyVal,
-                                      tomlFromTable)
+import Test.Toml.Parsing.Unit.Common (day2, parseToml, tomlFailOn)
 
 tomlSpecs :: Spec
 tomlSpecs = do
     describe "Key/values" $ do
         it "can parse key/value pairs" $ do
-            parseToml "x='abcdef'" (tomlFromKeyVal [(makeKey ["x"], AnyValue (Text "abcdef"))])
-            parseToml "x=1"        (tomlFromKeyVal [(makeKey ["x"], AnyValue (Integer 1))])
-            parseToml "x=5.2"      (tomlFromKeyVal [(makeKey ["x"], AnyValue (Double 5.2))])
-            parseToml "x=true"     (tomlFromKeyVal [(makeKey ["x"], AnyValue (Bool True))])
-            parseToml "x=[1, 2, 3]" (tomlFromKeyVal [(makeKey ["x"] , AnyValue (Array [Integer 1, Integer 2, Integer 3]))])
-            parseToml "x = 1920-12-10" (tomlFromKeyVal [(makeKey ["x"], AnyValue (Day day2))])
+            parseToml "x = 'abcdef'" $ mkToml ("x" =: Text "abcdef")
+            parseToml "x = 1"  $ mkToml ("x" =: Integer 1)
+            parseToml "x = 5.2" $ mkToml ("x" =: Double 5.2)
+            parseToml "x = true" $ mkToml ("x" =: Bool True)
+            parseToml "x = [1, 2, 3]" $ mkToml ("x" =: Array [Integer 1, Integer 2, Integer 3])
+            parseToml "x = 1920-12-10" $ mkToml ("x" =: Day day2)
         it "ignores white spaces around key names and values" $ do
-            let toml = tomlFromKeyVal [(makeKey ["x"], AnyValue (Integer 1))]
+            let toml = mkToml ("x" =: Integer 1)
             parseToml "x=1    "   toml
             parseToml "x=    1"   toml
             parseToml "x    =1"   toml
             parseToml "x\t= 1 "   toml
-            parseToml "\"x\" = 1" (tomlFromKeyVal [(makeKey [dquote "x"], AnyValue (Integer 1))])
+            parseToml "\"x\" = 1" $ mkToml ("\"x\"" =: Integer 1)
         --xit "fails if the key, equals sign, and value are not on the same line" $ do
         --  keyValFailOn "x\n=\n1"
         --  keyValFailOn "x=\n1"
         --  keyValFailOn "\"x\"\n=\n1"
         it "works if the value is broken over multiple lines" $
-            parseToml "x=[1, \n2\n]" (tomlFromKeyVal [(makeKey ["x"], AnyValue (Array [Integer 1, Integer 2]))])
+            parseToml "x=[1, \n2\n]" $ mkToml ("x" =: Array [Integer 1, Integer 2])
         it "fails if the value is not specified" $
             tomlFailOn "x="
 
     describe "tables" $ do
-        it "can parse a TOML table" $
-          parseToml "[table] \n key1 = \"some string\"\nkey2 = 123"
-                $ tomlFromTable [(makeKey ["table"], tomlFromKeyVal [str, int])]
+        it "can parse a TOML table" $ do
+            let t  = mkToml $
+                        table "table" $ do
+                            "key1" =: Text "some string"
+                            "key2" =: Integer 123
+
+            parseToml "[table] \n key1 = \"some string\"\nkey2 = 123" t
         it "can parse an empty TOML table" $
-            parseToml "[table]" (tomlFromTable [(makeKey ["table"], mempty)])
+            parseToml "[table]" $ mkToml (table "table" empty)
         it "can parse a table with subarrays" $ do
-            let t = tomlFromTable [(makeKey ["table"], tomlFromArray [(makeKey ["array"], strT :| [intT])])]
+            let t = mkToml $
+                        table "table" $
+                            tableArray "array" ("key1" =: Text "some string" :| ["key2" =: Integer 123])
+
             parseToml "[table] \n [[table.array]] \nkey1 = \"some string\"\n \
                                   \[[table.array]] \nkey2 = 123" t
         it "can parse a TOML inline table" $
-            parseToml "table={key1 = \"some string\", key2 = 123}"
-                (tomlFromTable [(makeKey ["table"], tomlFromKeyVal [str, int])])
+            parseToml "table={key1 = \"some string\", key2 = 123}" $
+                mkToml $
+                    table "table" $ do
+                        "key1" =: Text "some string"
+                        "key2" =: Integer 123
         it "can parse an empty inline TOML table" $
-            parseToml "table = {}" (tomlFromTable [(makeKey ["table"], mempty)])
+            parseToml "table = {}" $ mkToml (table "table" empty)
         it "can parse a table followed by an inline table" $
-            parseToml "[table1] \n  key1 = \"some string\" \n table2 = {key2 = 123}"
-                (tomlFromTable
-                    [ ( "table1"
-                      , tomlFromKeyVal [str]
-                        <> tomlFromTable [ ("table2", tomlFromKeyVal [int]) ]
-                      )
-                    ]
-                )
+            parseToml "[table1] \n  key1 = \"some string\" \n table2 = {key2 = 123}" $
+                mkToml $
+                    table "table1" $ do
+                        "key1" =: Text "some string"
+                        table "table2" $ "key2" =: Integer 123
         it "can parse an empty table followed by an inline table" $
-            parseToml "[table1] \n table2 = {key2 = 123}"
-                (tomlFromTable
-                    [ ( "table1"
-                      , tomlFromTable [ ("table2", tomlFromKeyVal [int]) ]
-                      )
-                    ]
-                )
+            parseToml "[table1] \n table2 = {key2 = 123}" $
+                mkToml $
+                    table "table1" $
+                        table "table2" $
+                            "key2" =: Integer 123
         it "allows the name of the table to be any valid TOML key" $ do
-            parseToml "dog.\"tater.man\"={}"
-                (tomlFromTable [(makeKey ["dog", dquote "tater.man"], mempty)])
-            parseToml "j.\"ʞ\".'l'={}"
-                (tomlFromTable [(makeKey ["j", dquote "ʞ", squote "l"], mempty)])
+            parseToml "dog.\"tater.man\"={}" $ mkToml $ table ("dog" :|| ["\"tater.man\""]) empty
+            parseToml "j.\"ʞ\".'l'={}" $ mkToml $ table "j.\"ʞ\".'l'" empty
 
     describe "array of tables" $ do
         it "can parse an empty array" $
-            parseToml "[[array]]" (tomlFromArray [(makeKey ["array"], mempty :| [])])
+            parseToml "[[array]]" $ mkToml $ tableArray "array" (empty :| [])
         it "can parse an array of key/values" $ do
-            let array = tomlFromArray [(makeKey ["array"], NE.fromList [strT, intT])]
+            let array = mkToml $
+                        tableArray "array" $
+                            "key1" =: Text "some string" :|
+                            ["key2" =: Integer 123]
+
             parseToml "[[array]]\n key1 = \"some string\"\n \
-                      \[[array]]\n key2 = 123" array
+                       \[[array]]\n key2 = 123" array
         it "can parse an array of tables" $ do
-            let table1 = tomlFromTable [(makeKey ["table1"], strT)]
-                table2 = tomlFromTable [(makeKey ["table2"], intT)]
-                array  = tomlFromArray [(makeKey ["array"], NE.fromList [table1, table2])]
+            let table1 = table "table1" ("key1" =: Text "some string")
+                table2 = table "table2" ("key2" =: Integer 123)
+                array = mkToml $ tableArray "array" $ table1 :| [table2]
+
             parseToml "[[array]]\n[array.table1] \n key1 = \"some string\"\n \
-                      \[[array]]\n[array.table2] \n key2 = 123" array
+                       \[[array]]\n[array.table2] \n key2 = 123" array
         it "can parse an array of array" $ do
-            let arr = tomlFromArray [(makeKey ["subarray"], NE.fromList [strT, intT])]
-                array = tomlFromArray [(makeKey ["array"], arr :| [])]
+            let arr = tableArray "subarray" ("key1" =: Text "some string" :| ["key2" =: Integer 123])
+                array = mkToml $ tableArray "array" (arr :| [])
+
             parseToml "[[array]] \n [[array.subarray]] \nkey1 = \"some string\"\n \
-                      \[[array.subarray]] \nkey2 = 123" array
-        it "can parse an array of arrays" $ do
-            let arr1 = (makeKey ["table-1"], strT :| [])
-                arr2 = (makeKey ["table-2"], intT :| [])
-                array = tomlFromArray [(makeKey ["array"], tomlFromArray [arr1, arr2] :| [])]
-            parseToml "[[array]]\n [[array.table-1]] \nkey1 = \"some string\"\n \
-                                  \[[array.table-2]] \nkey2 = 123" array
+                       \[[array.subarray]] \nkey2 = 123" array
+        -- TODO this does not work currently, Edsl does not seem to be able to generate arrays of tables with more than one different property
+        --it "can parse an array of arrays" $ do
+            --let
+                --arr1 = tableArray "table-1" ("key1" =: Text "some string" :| [])
+                --arr2 = tableArray "table-2" ("key2" =: Integer 123 :| [])
+                --array = mkToml $ tableArray "array" $ arr1 :| [arr2]
+
+            --parseToml "[[array]]\n [[array.table-1]] \nkey1 = \"some string\"\n \
+                                    -- \[[array.table-2]] \nkey2 = 123" array
         it "can parse very large arrays" $ do
-            let array = tomlFromArray [(makeKey ["array"], NE.fromList $ replicate 1000 mempty)]
+            let array = mkToml $ tableArray "array" $ NE.fromList $ replicate 1000 empty
             parseToml (mconcat $ replicate 1000 "[[array]]\n") array
         it "can parse an inline array of tables" $ do
-            let array  = tomlFromArray [(makeKey ["table"], NE.fromList [strT, intT])]
+            let array = mkToml $ tableArray "table" $ NE.fromList ["key1" =: Text "some string", "key2" =: Integer 123]
             parseToml "table = [{key1 = \"some string\"}, {key2 = 123}]" array
 
     describe "TOML" $ do

--- a/test/Test/Toml/Parsing/Unit/Toml.hs
+++ b/test/Test/Toml/Parsing/Unit/Toml.hs
@@ -109,15 +109,14 @@ tomlSpecs = do
 
             parseToml "[[array]] \n [[array.subarray]] \nkey1 = \"some string\"\n \
                        \[[array.subarray]] \nkey2 = 123" array
-        -- TODO this does not work currently, Edsl does not seem to be able to generate arrays of tables with more than one different property
-        --it "can parse an array of arrays" $ do
-            --let
-                --arr1 = tableArray "table-1" ("key1" =: Text "some string" :| [])
-                --arr2 = tableArray "table-2" ("key2" =: Integer 123 :| [])
-                --array = mkToml $ tableArray "array" $ arr1 :| [arr2]
+        it "can parse an array of arrays" $ do
+            let
+                arr1 = tableArray "table-1" ("key1" =: Text "some string" :| [])
+                arr2 = tableArray "table-2" ("key2" =: Integer 123 :| [])
+                array = mkToml $ tableArray "array" $ (arr1 >> arr2) :| []
 
-            --parseToml "[[array]]\n [[array.table-1]] \nkey1 = \"some string\"\n \
-                                    -- \[[array.table-2]] \nkey2 = 123" array
+            parseToml "[[array]]\n [[array.table-1]] \nkey1 = \"some string\"\n \
+                                     \[[array.table-2]] \nkey2 = 123" array
         it "can parse very large arrays" $ do
             let array = mkToml $ tableArray "array" $ NE.fromList $ replicate 1000 empty
             parseToml (mconcat $ replicate 1000 "[[array]]\n") array


### PR DESCRIPTION
Fixes #217. 

This PR is a refactoring of the `Test.Toml.Parsing.Unit.Toml` tests to use the TOML Edsl in the library. 
Sadly I couldn't figure out how to construct the array of arrays as written in the TODO in the code. A lot of time went into wondering whether the Edsl allows array values with more than one property and I couldn't see how. :/