### PR TITLE
[#203] Encode / decode Map-like data structures

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,12 @@
 tomland uses [PVP Versioning][1].
 The changelog is available [on GitHub][2].
 
+## 1.2.1.0 — Nov 3, 2019
+
+* [#203](https://github.com/kowainik/tomland/issues/203):
+  Implement codecs for `Map`-like data structures.
+  (by [@chshersh](https://github.com/chshersh))
+
 ## 1.2.0.0 — Oct 12, 2019
 
 * [#216](https://github.com/kowainik/tomland/issues/216):

--- a/examples/Main.hs
+++ b/examples/Main.hs
@@ -7,6 +7,7 @@ import Control.Applicative ((<|>))
 import Control.Arrow ((>>>))
 import Data.Hashable (Hashable)
 import Data.HashSet (HashSet)
+import Data.Map.Strict (Map)
 import Data.Set (Set)
 import Data.Text (Text)
 import Data.Time (fromGregorian)
@@ -84,6 +85,7 @@ data Test = Test
     , users      :: ![User]
     , susers     :: !(Set User)
     , husers     :: !(HashSet User)
+    , payloads   :: !(Map Text Int)
     }
 
 
@@ -105,6 +107,7 @@ testT = Test
     <*> Toml.list userCodec "user" .= users
     <*> Toml.set userCodec "suser" .= susers
     <*> Toml.hashSet userCodec "huser" .= husers
+    <*> Toml.map (Toml.text "name") (Toml.int "payload") "payloads" .= payloads
   where
     -- different keys for sum type
     eitherT1 :: TomlCodec (Either Integer String)

--- a/examples/biTest.toml
+++ b/examples/biTest.toml
@@ -17,6 +17,11 @@ either = 3.5
 # Also works!
 # either = "fo  o"
 
+payloads =
+    [ { name = "foo", payload = 42 }
+    , { name = "bar", payload = 69 }
+    ]
+
 [testX]
   inside = "xxx"
 

--- a/test/Test/Toml/BiCode/Property.hs
+++ b/test/Test/Toml/BiCode/Property.hs
@@ -1,11 +1,12 @@
 module Test.Toml.BiCode.Property where
 
-import Control.Applicative ((<|>))
+import Control.Applicative (liftA2, (<|>))
 import Control.Category ((>>>))
 import Data.ByteString (ByteString)
 import Data.HashSet (HashSet)
 import Data.IntSet (IntSet)
 import Data.List.NonEmpty (NonEmpty)
+import Data.Map.Strict (Map)
 import Data.Set (Set)
 import Data.Text (Text)
 import Data.Time (Day, LocalTime, TimeOfDay, ZonedTime, zonedTimeToUTC)
@@ -56,6 +57,7 @@ data BigType = BigType
     , btNewtype       :: !BigTypeNewtype
     , btSum           :: !BigTypeSum
     , btRecord        :: !BigTypeRecord
+    , btMap           :: !(Map Int Bool)
     } deriving stock (Show, Eq)
 
 -- | Wrapper over 'Double' and 'Float' to be equal on @NaN@ values.
@@ -112,6 +114,7 @@ bigTypeCodec = BigType
     <*> Toml.diwrap (Toml.zonedTime "nt.zonedTime")                .= btNewtype
     <*> bigTypeSumCodec                                            .= btSum
     <*> Toml.table bigTypeRecordCodec        "table-record"        .= btRecord
+    <*> Toml.map (Toml.int "key") (Toml.bool "val") "map"          .= btMap
 
 _BigTypeSumA :: TomlBiMap BigTypeSum Integer
 _BigTypeSumA = Toml.prism BigTypeSumA $ \case
@@ -163,6 +166,7 @@ genBigType = do
     btNewtype       <- genNewType
     btSum           <- genSum
     btRecord        <- genRec
+    btMap           <- Gen.map (Range.constant 0 10) (liftA2 (,) genInt genBool)
     pure BigType {..}
 
 -- Custom generators

--- a/tomland.cabal
+++ b/tomland.cabal
@@ -1,6 +1,6 @@
 cabal-version:       2.4
 name:                tomland
-version:             1.2.0.0
+version:             1.2.1.0
 synopsis:            Bidirectional TOML serialization
 description:
     Implementation of bidirectional TOML serialization. Simple codecs look like this:


### PR DESCRIPTION
Resolves #203

This PR implements bidirectional codec for `Map` data structure. I didn't implement it for `HashMap` because it's more boilerplate and it's not apparent how to get rid of it... I've tested it locally and added more tests, and it works!

I think some improvements can be made later once we get a better understanding of what we want. But the current interface seems reasonable to me.