### PR TITLE
[#246] Bump up to megaparsec-8.0.0

### DIFF
--- a/tomland.cabal
+++ b/tomland.cabal
@@ -101,7 +101,7 @@ library
                      , containers >= 0.5.7 && < 0.7
                      , deepseq ^>= 1.4
                      , hashable >= 1.2 && < 1.4
-                     , megaparsec ^>= 7.0.5
+                     , megaparsec >= 7.0.5 && < 8.1
                      , mtl ^>= 2.2
                      , parser-combinators >= 1.1.0 && < 1.3
                      , text ^>= 1.2
@@ -166,7 +166,7 @@ test-suite tomland-test
                      , containers >= 0.5.7 && < 0.7
                      , hashable
                      , hedgehog ^>= 1.0.1
-                     , hspec-megaparsec ^>= 2.0.0
+                     , hspec-megaparsec >= 2.0.0 && < 2.2.0
                      , megaparsec
                      , tasty ^>= 1.2
                      , tasty-hedgehog ^>= 1.0.0.0


### PR DESCRIPTION
Resolves #246

I made sure locally that `megaparsec-8.0.0` is used and that the code builds and all tests are passing with `megaparsec-8.0.0`.