### PR TITLE
[#202] Add property tests for generic codec

### DIFF
--- a/src/Toml/Generic.hs
+++ b/src/Toml/Generic.hs
@@ -127,6 +127,7 @@ import Data.IntSet (IntSet)
 import Data.Kind (Type)
 import Data.List (stripPrefix)
 import Data.List.NonEmpty (NonEmpty)
+import Data.Monoid (All (..), Any (..), First (..), Last (..), Product (..), Sum (..))
 import Data.Proxy (Proxy (..))
 import Data.Set (Set)
 import Data.String (IsString (..))
@@ -372,6 +373,30 @@ instance (Hashable a, Eq a, HasItemCodec a) => HasCodec (HashSet a) where
     hasCodec = case hasItemCodec @a of
         Left prim   -> Toml.arrayHashSetOf prim
         Right codec -> Toml.hashSet codec
+
+-- | @since 1.x.x.x
+instance HasCodec All where
+    hasCodec = Toml.diwrap . hasCodec @Bool
+
+-- | @since 1.x.x.x
+instance HasCodec Any where
+    hasCodec = Toml.diwrap . hasCodec @Bool
+
+-- | @since 1.x.x.x
+instance HasCodec a => HasCodec (Sum a) where
+    hasCodec = Toml.diwrap . hasCodec @a
+
+-- | @since 1.x.x.x
+instance HasCodec a => HasCodec (Product a) where
+    hasCodec = Toml.diwrap . hasCodec @a
+
+-- | @since 1.x.x.x
+instance HasCodec a => HasCodec (First a) where
+    hasCodec = Toml.diwrap . hasCodec @(Maybe a)
+
+-- | @since 1.x.x.x
+instance HasCodec a => HasCodec (Last a) where
+    hasCodec = Toml.diwrap . hasCodec @(Maybe a)
 
 {-
 TODO: uncomment when higher-kinded roles will be implemented


### PR DESCRIPTION
First of all, thanks for the great pointers for this PR! A couple of notes:

* This type required a couple more instances of `HasCodec` and `HasItemCodec` for a couple of external types ( Char, ByteString, Map and the various Monoid newtypes ). I've put these as orphan instances in the test file ( as I see was done in the `BiMap` property tests ). But some of them could be added to the `Generic` file as well ( ByteString and Char ), but I thought it would be better to discuss it.
* I had some problems with deriving a generic codec for the `BigTypeSum` and i'm not sure if it's possible to do so. Am I missing something? What I could do is ( since that is the only use case I can think of for a sum type ) is replace the `btSumType` field with a list of `BigSumType` and make the codec like that. 
