### PR TITLE
[#277] Fill missing parts in tests

### DIFF
--- a/src/Toml/Codec/BiMap/Conversion.hs
+++ b/src/Toml/Codec/BiMap/Conversion.hs
@@ -47,8 +47,8 @@ module Toml.Codec.BiMap.Conversion
     , _Array
     , _NonEmpty
     , _Set
-    , _IntSet
     , _HashSet
+    , _IntSet
     , _ByteStringArray
     , _LByteStringArray
 

--- a/test/Test/Toml/Codec/BiMap.hs
+++ b/test/Test/Toml/Codec/BiMap.hs
@@ -4,11 +4,64 @@ module Test.Toml.Codec.BiMap
     ( biMapSpec
     ) where
 
-import Test.Hspec (Spec, describe)
+import Prelude hiding (id, (.))
+
+import Control.Category (id, (.))
+import Data.Word (Word8)
+import Hedgehog (Gen, PropertyT, forAll, (===))
+import Test.Hspec (Spec, describe, it)
+import Test.Hspec.Hedgehog (hedgehog)
 
 import Test.Toml.Codec.BiMap.Conversion (conversionSpec)
+import Test.Toml.Gen (genInteger, genText, genWord8)
+import Toml.Codec.BiMap (BiMap (..), TomlBiMap)
+import Toml.Codec.BiMap.Conversion (_BoundedInteger, _ReadString, _StringText)
 
 
 biMapSpec :: Spec
-biMapSpec = describe "Tagged Partial Bidirectional Isomorphism: tests" $
+biMapSpec = describe "Tagged Partial Bidirectional Isomorphism: tests" $ do
     conversionSpec
+    categoryLaws
+
+categoryLaws :: Spec
+categoryLaws = describe "Category laws" $ do
+    it "Right identity: f . id ≡ f" $ biMapEquality
+        (_Word8Integer . id)
+        _Word8Integer
+        genWord8
+        genInteger
+
+    it "Left identity:  id . f ≡ f" $ biMapEquality
+        _Word8Integer
+        (_Word8Integer . id)
+        genWord8
+        genInteger
+
+    it "Associativity:  f . (g . h) ≡ (f . g) . h" $ biMapEquality
+        (_StringText . (_ReadString . _Word8Integer))
+        ((_StringText . _ReadString) . _Word8Integer)
+        genWord8
+        genText
+
+{- | Property that takes two 'BiMap's and checks them on equality. We
+consider two 'BiMap's @m1@ and @m2@ equal iff:
+
+* @forward  m1 ≡ forward  m2@
+* @backward m1 ≡ backward m2@
+-}
+biMapEquality
+    :: (Eq a, Eq b, Show a, Show b)
+    => TomlBiMap a b
+    -> TomlBiMap a b
+    -> Gen a
+    -> Gen b
+    -> PropertyT IO ()
+biMapEquality m1 m2 genA genB = hedgehog $ do
+    a <- forAll genA
+    b <- forAll genB
+
+    forward  m1 a === forward  m2 a
+    backward m1 b === backward m2 b
+
+_Word8Integer :: TomlBiMap Word8 Integer
+_Word8Integer = _BoundedInteger

--- a/test/Test/Toml/Codec/BiMap.hs
+++ b/test/Test/Toml/Codec/BiMap.hs
@@ -24,7 +24,7 @@ biMapSpec = describe "Tagged Partial Bidirectional Isomorphism: tests" $ do
     categoryLaws
 
 categoryLaws :: Spec
-categoryLaws = describe "Category laws" $ do
+categoryLaws = describe "BiMap Category instance laws" $ do
     it "Right identity: f . id ≡ f" $ biMapEquality
         (_Word8Integer . id)
         _Word8Integer
@@ -44,7 +44,7 @@ categoryLaws = describe "Category laws" $ do
         genText
 
 {- | Property that takes two 'BiMap's and checks them on equality. We
-consider two 'BiMap's @m1@ and @m2@ equal iff:
+consider two 'BiMap's @m1@ and @m2@ equal if:
 
 * @forward  m1 ≡ forward  m2@
 * @backward m1 ≡ backward m2@

--- a/test/Test/Toml/Codec/BiMap/Conversion.hs
+++ b/test/Test/Toml/Codec/BiMap/Conversion.hs
@@ -19,31 +19,45 @@ import qualified Toml.Codec.BiMap.Conversion as B
 
 conversionSpec :: Spec
 conversionSpec = describe "BiMap Rountrip Property tests" $ do
-    it "Bool" (testBiMap B._Bool G.genBool)
-    it "Integer" (testBiMap B._Integer G.genInteger)
-    it "Natural" (testBiMap B._Natural G.genNatural)
-    it "Int" (testBiMap B._Int G.genInt)
-    it "Word" (testBiMap B._Word G.genWord)
-    it "Word8" (testBiMap B._Word8 G.genWord8)
-    it "Double" testDouble
-    it "Float" (testBiMap B._Float G.genFloat)
-    it "Text" (testBiMap B._Text G.genText)
-    it "LazyText" (testBiMap B._LText G.genLText)
-    it "String" (testBiMap B._String G.genString)
-    it "Read (Integer)" (testBiMap B._Read G.genInteger)
-    it "ByteString" (testBiMap B._ByteString G.genByteString)
-    it "Lazy ByteString" (testBiMap B._LByteString G.genLByteString)
-    it "ByteStringArray" (testBiMap B._ByteStringArray G.genByteString)
-    it "Lazy ByteStringArray" (testBiMap B._LByteStringArray G.genLByteString)
-    it "ZonedTime" (testBiMap B._ZonedTime G.genZoned)
-    it "LocalTime" (testBiMap B._LocalTime G.genLocal)
-    it "TimeOfDay" (testBiMap B._TimeOfDay G.genHours)
-    it "Day" (testBiMap B._Day G.genDay)
-    it "IntSet" (testBiMap B._IntSet G.genIntSet)
-    it "Array (Day)" (testBiMap (B._Array B._Day) (G.genList G.genDay))
-    it "Set (Day)" (testBiMap (B._Set B._Day) (Gen.set G.range100 G.genDay))
-    it "NonEmpty (Day)" (testBiMap (B._NonEmpty B._Day) (G.genNonEmpty G.genDay))
-    it "HashSet (Integer)" (testBiMap (B._HashSet B._Integer) (G.genHashSet G.genInteger))
+    describe "Primitive" $ do
+        it "Bool"            $ testBiMap B._Bool G.genBool
+        it "Int"             $ testBiMap B._Int G.genInt
+        it "Word"            $ testBiMap B._Word G.genWord
+        it "Word8"           $ testBiMap B._Word8 G.genWord8
+        it "Integer"         $ testBiMap B._Integer G.genInteger
+        it "Natural"         $ testBiMap B._Natural G.genNatural
+        it "Double"          testDouble
+        it "Float"           $ testBiMap B._Float G.genFloat
+        it "Text"            $ testBiMap B._Text G.genText
+        it "LazyText"        $ testBiMap B._LText G.genLText
+        it "ByteString"      $ testBiMap B._ByteString G.genByteString
+        it "Lazy ByteString" $ testBiMap B._LByteString G.genLByteString
+        it "String"          $ testBiMap B._String G.genString
+
+    describe "Time" $ do
+        it "ZonedTime" $ testBiMap B._ZonedTime G.genZoned
+        it "LocalTime" $ testBiMap B._LocalTime G.genLocal
+        it "Day"       $ testBiMap B._Day G.genDay
+        it "TimeOfDay" $ testBiMap B._TimeOfDay G.genHours
+
+    describe "Arrays" $ do
+        it "Array (Int)"      $ testBiMap (B._Array B._Int) (G.genList G.genInt)
+        it "Array (Day)"      $ testBiMap (B._Array B._Day) (G.genList G.genDay)
+        it "NonEmpty (Int)"   $ testBiMap (B._NonEmpty B._Int) (G.genNonEmpty G.genInt)
+        it "Set (Int)"        $ testBiMap (B._Set B._Int) (G.genSet G.genInt)
+        it "HashSet (Int)"    $ testBiMap (B._HashSet B._Int) (G.genHashSet G.genInt)
+        it "IntSet"           $ testBiMap B._IntSet G.genIntSet
+        it "ByteStringArray"  $ testBiMap B._ByteStringArray G.genByteString
+        it "LByteStringArray" $ testBiMap B._LByteStringArray G.genLByteString
+
+    describe "Custom" $ do
+        it "EnumBounded (Ordering)" $ testBiMap B._EnumBounded $ Gen.enumBounded @_ @Ordering
+        it "Read (Integer)"         $ testBiMap B._Read G.genInteger
+        it "TextBy (Text)"          $ testBiMap (B._TextBy id Right) G.genText
+
+    describe "Key" $ do
+        it "KeyText"   $ testBiMap B._KeyText G.genKey
+        it "KeyString" $ testBiMap B._KeyString G.genKey
 
 testBiMap
     :: (Show a, Show b, Eq a)

--- a/test/Test/Toml/Gen.hs
+++ b/test/Test/Toml/Gen.hs
@@ -20,6 +20,7 @@ module Test.Toml.Gen
 
        , genList
        , genNonEmpty
+       , genSet
        , genHashSet
        , genIntSet
 
@@ -56,6 +57,7 @@ import Data.HashMap.Strict (HashMap)
 import Data.HashSet (HashSet)
 import Data.IntSet (IntSet)
 import Data.List.NonEmpty (NonEmpty)
+import Data.Set (Set)
 import Data.Text (Text)
 import Data.Time (Day, LocalTime (..), TimeOfDay (..), ZonedTime (..), fromGregorian,
                   minutesToTimeZone)
@@ -237,6 +239,9 @@ genNatural = fromIntegral <$> genWord
 
 genFloat :: Gen Float
 genFloat = Gen.float (Range.constant (-10000.0) 10000.0)
+
+genSet :: Ord a => Gen a -> Gen (Set a)
+genSet genA = fromList <$> genList genA
 
 genHashSet :: (Eq a, Hashable a) => Gen a -> Gen (HashSet a)
 genHashSet genA = fromList <$> genList genA

--- a/test/Test/Toml/Type/Key.hs
+++ b/test/Test/Toml/Type/Key.hs
@@ -40,3 +40,5 @@ keysDiffSpec = describe "Key difference" $ do
         keysDiff "key.foo" "key.bar" `shouldBe` Diff "key" "foo" "bar"
     it "Diff: Two components" $
         keysDiff "key.nest.foo" "key.nest.bar" `shouldBe` Diff "key.nest" "foo" "bar"
+    it "Diff: Two diff components" $
+        keysDiff "key.foo.nest" "key.bar.nest" `shouldBe` Diff "key" "foo.nest" "bar.nest"

--- a/test/Test/Toml/Type/Key.hs
+++ b/test/Test/Toml/Type/Key.hs
@@ -30,8 +30,10 @@ keysDiffSpec = describe "Key difference" $ do
         keysDiff "key" "key" `shouldBe` Equal
     it "Equal: Complex" $
         keysDiff "foo.bar.baz" "foo.bar.baz" `shouldBe` Equal
-    it "NoPrefix" $
+    it "NoPrefix: Simple" $
         keysDiff "foo" "bar" `shouldBe` NoPrefix
+    it "NoPrefix: Only common suffix" $
+        keysDiff "foo.key" "bar.key" `shouldBe` NoPrefix
     it "FstIsPref" $
         keysDiff "key" "key.nest" `shouldBe` FstIsPref "nest"
     it "SndIsPref" $
@@ -42,3 +44,5 @@ keysDiffSpec = describe "Key difference" $ do
         keysDiff "key.nest.foo" "key.nest.bar" `shouldBe` Diff "key.nest" "foo" "bar"
     it "Diff: Two diff components" $
         keysDiff "key.foo.nest" "key.bar.nest" `shouldBe` Diff "key" "foo.nest" "bar.nest"
+    it "Diff: Different diff length" $
+        keysDiff "key.foo" "key.bar.nest" `shouldBe` Diff "key" "foo" "bar.nest"

--- a/test/Test/Toml/Type/Key.hs
+++ b/test/Test/Toml/Type/Key.hs
@@ -4,20 +4,39 @@ module Test.Toml.Type.Key
 
 import Data.String (IsString (..))
 import Hedgehog (forAll, tripping)
-import Test.Hspec (Arg, Expectation, Spec, SpecWith, describe, it)
+import Test.Hspec (Arg, Expectation, Spec, SpecWith, describe, it, shouldBe)
 import Test.Hspec.Hedgehog (hedgehog)
 
 import Test.Toml.Gen (genKey)
+import Toml.Type.Key (KeysDiff (..), keysDiff)
 
 import qualified Data.Text as Text
 import qualified Toml.Type.Printer as Printer
 
 
 keySpec :: Spec
-keySpec = describe "TOML Key"
+keySpec = describe "TOML Key" $ do
     keyRoundtripSpec
+    keysDiffSpec
 
 keyRoundtripSpec :: SpecWith (Arg Expectation)
 keyRoundtripSpec = it "Key printing: fromString . prettyKey ≡ id" $ hedgehog $ do
     key <- forAll genKey
     tripping key Printer.prettyKey (Just . fromString . Text.unpack)
+
+keysDiffSpec :: Spec
+keysDiffSpec = describe "Key difference" $ do
+    it "Equal: Simple" $
+        keysDiff "key" "key" `shouldBe` Equal
+    it "Equal: Complex" $
+        keysDiff "foo.bar.baz" "foo.bar.baz" `shouldBe` Equal
+    it "NoPrefix" $
+        keysDiff "foo" "bar" `shouldBe` NoPrefix
+    it "FstIsPref" $
+        keysDiff "key" "key.nest" `shouldBe` FstIsPref "nest"
+    it "SndIsPref" $
+        keysDiff "key.nest" "key" `shouldBe` SndIsPref "nest"
+    it "Diff: Simple" $
+        keysDiff "key.foo" "key.bar" `shouldBe` Diff "key" "foo" "bar"
+    it "Diff: Two components" $
+        keysDiff "key.nest.foo" "key.nest.bar" `shouldBe` Diff "key.nest" "foo" "bar"


### PR DESCRIPTION
Resolves #277

For `Category` laws: ideally, those tests should generate random `BiMap` but this is too complicated. So I'm just checking the laws for the specific `TomlBiMap`. I guess this should be enough for now.