### PR TITLE
[#325] Add ptint option for array type

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@ The changelog is available [on GitHub][2].
 ## Unrelised
 
 * [#325](https://github.com/kowainik/tomland/issues/325):
-  PrintOptions for lists
+  Add ability to one or multiline printing to `PrintOptions` for arrays.
 
 ## 1.3.1.0 — Sep 21, 2020
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ The changelog is available [on GitHub][2].
 
 ## Unrelised
 
-* [#325](https://github.com/kowainik/tomland/issues/325)
+* [#325](https://github.com/kowainik/tomland/issues/325):
   PrintOptions for lists
 
 ## 1.3.1.0 — Sep 21, 2020

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,11 @@
 `tomland` uses [PVP Versioning][1].
 The changelog is available [on GitHub][2].
 
+## Unrelised
+
+* [#325](https://github.com/kowainik/tomland/issues/325)
+  PrintOptions for lists
+
 ## 1.3.1.0 — Sep 21, 2020
 
 * [#331](https://github.com/kowainik/tomland/issues/331):

--- a/src/Toml/Codec/Types.hs
+++ b/src/Toml/Codec/Types.hs
@@ -48,6 +48,7 @@ type TomlEnv a = TOML -> Validation [TomlDecodeError] a
 
 {- | Specialied 'Codec' type alias for bidirectional TOML serialization. Keeps
 'TOML' object as both environment and state.
+class (B.BeamSqlBackend be, B.MonadBeam be beM) => BeamRuntime be beM
 
 @since 0.5.0
 -}

--- a/src/Toml/Codec/Types.hs
+++ b/src/Toml/Codec/Types.hs
@@ -48,7 +48,6 @@ type TomlEnv a = TOML -> Validation [TomlDecodeError] a
 
 {- | Specialied 'Codec' type alias for bidirectional TOML serialization. Keeps
 'TOML' object as both environment and state.
-class (B.BeamSqlBackend be, B.MonadBeam be beM) => BeamRuntime be beM
 
 @since 0.5.0
 -}

--- a/src/Toml/Type/Printer.hs
+++ b/src/Toml/Type/Printer.hs
@@ -12,6 +12,7 @@ Contains functions for pretty printing @toml@ types.
 
 module Toml.Type.Printer
        ( PrintOptions(..)
+       , Lines(..)
        , defaultOptions
        , pretty
        , prettyOptions
@@ -248,7 +249,7 @@ addPrefix key = \case
     prefix -> prefix <> "." <> prettyKey key
 
 withLines :: PrintOptions -> Int -> (Int -> Value t -> Text) -> [Value t] -> Text
-withLines options@PrintOptions{..} offLength valTxt a = case printOptionsLines of
+withLines PrintOptions{..} offLength valTxt a = case printOptionsLines of
     OneLine -> "[" <> Text.intercalate ", " (map (valTxt offLength) a) <> "]"
     MultiLine -> off <> "[ " <> Text.intercalate (off <> ", ") (map (valTxt offLength) a) <> off <> "]"
   where

--- a/src/Toml/Type/Printer.hs
+++ b/src/Toml/Type/Printer.hs
@@ -57,15 +57,21 @@ data PrintOptions = PrintOptions
     , printOptionsIndent  :: !Int
     {- | How to print Array.
       OneLine:
+      
+      @
       foo = [a, b]
+      @
 
       MultiLine:
+      
+      @
       foo =
           [ a
           , b
           ]
+      @
 
-      Default is OneLine
+      Default is 'OneLine'.
     -}
     , printOptionsLines :: !Lines
     }

--- a/test/Test/Toml/Type/Printer.hs
+++ b/test/Test/Toml/Type/Printer.hs
@@ -11,7 +11,7 @@ import Test.Hspec.Golden (defaultGolden)
 
 import Toml.Type.Edsl (empty, mkToml, table, tableArray, (=:))
 import Toml.Type.Key (Key (..), (<|))
-import Toml.Type.Printer (PrintOptions (..), defaultOptions, prettyOptions)
+import Toml.Type.Printer (PrintOptions (..), Lines(..), defaultOptions, prettyOptions)
 import Toml.Type.TOML (TOML)
 import Toml.Type.Value (Value (..))
 
@@ -25,6 +25,7 @@ printerSpec = describe "Toml.Type.Printer: Golden tests for pretty-printing" $ d
     test "pretty_indented_only" noFormatting { printOptionsIndent = 4 }
     test "pretty_unformatted" noFormatting
     test "pretty_custom_sorted" noFormatting { printOptionsSorting = Just spamEgg }
+    test "pretty_lines" defaultOptions { printOptionsLines = MultiLine }
   where
     test :: String -> PrintOptions -> SpecWith (Arg Expectation)
     test name options = it ("Golden " ++ name) $
@@ -44,6 +45,7 @@ example = mkToml $ do
     table "foo" empty
     table "doo" empty
     table "baz" empty
+    "list" =: Array ["one", "two"]
     tableArray "deepest" $
       "ping" =: "pong"
       :| [empty]
@@ -55,6 +57,7 @@ noFormatting :: PrintOptions
 noFormatting = PrintOptions
     { printOptionsSorting = Nothing
     , printOptionsIndent  = 0
+    , printOptionsLines = OneLine
     }
 
 -- | Decorate keys as tuples so spam comes before egg

--- a/test/golden/pretty_custom_sorted.golden
+++ b/test/golden/pretty_custom_sorted.golden
@@ -9,6 +9,8 @@ d = "ddd"
 
 [foo]
 
+list = ["one", "two"]
+
 [qux.doo]
 spam = "!"
 egg = "?"

--- a/test/golden/pretty_indented_only.golden
+++ b/test/golden/pretty_indented_only.golden
@@ -9,6 +9,8 @@ b = "bb"
 
 [baz]
 
+list = ["one", "two"]
+
 [qux.doo]
     egg = "?"
     spam = "!"

--- a/test/golden/pretty_lines.golden
+++ b/test/golden/pretty_lines.golden
@@ -5,7 +5,10 @@ d = "ddd"
 
 [baz]
 
-list = ["one", "two"]
+list =
+     [ "one"
+     , "two"
+     ]
 
 [doo]
 

--- a/test/golden/pretty_lines.golden
+++ b/test/golden/pretty_lines.golden
@@ -6,9 +6,9 @@ d = "ddd"
 [baz]
 
 list =
-     [ "one"
-     , "two"
-     ]
+  [ "one"
+  , "two"
+  ]
 
 [doo]
 

--- a/test/golden/pretty_sorted_only.golden
+++ b/test/golden/pretty_sorted_only.golden
@@ -5,6 +5,8 @@ d = "ddd"
 
 [baz]
 
+list = ["one", "two"]
+
 [doo]
 
 [foo]

--- a/test/golden/pretty_unformatted.golden
+++ b/test/golden/pretty_unformatted.golden
@@ -9,6 +9,8 @@ b = "bb"
 
 [baz]
 
+list = ["one", "two"]
+
 [qux.doo]
 egg = "?"
 spam = "!"


### PR DESCRIPTION
Resolve #325 

Do we need additional `pretty` function with argument for lines. Or library's users can implement it by self?

Also, for offset I pass through as argument, probably there is better way.