### PR TITLE
Leading zero

### DIFF
--- a/src/Toml/Parser/Value.hs
+++ b/src/Toml/Parser/Value.hs
@@ -25,7 +25,7 @@ import Data.Time (Day, LocalTime (..), TimeOfDay, ZonedTime (..), fromGregorianV
 import Data.String (fromString)
 
 import Text.Read (readMaybe)
-import Text.Megaparsec (parseMaybe)
+import Text.Megaparsec (observing, parseMaybe)
 
 import Toml.Parser.Core (Parser, char, digitChar, hexDigitChar, octDigitChar, binDigitChar, hexadecimal, octal, binary, lexeme, sc, signed,
                          string, text, try, (<?>))
@@ -35,14 +35,28 @@ import Toml.Type (AnyValue, UValue (..), typeCheck)
 
 -- | Parser for decimap 'Integer': included parsing of underscore.
 decimalP :: Parser Integer
-decimalP = zero <|> more
+decimalP = do
+        value <- observing $ try leadingZeroP
+        case value of
+          Left (_) -> do
+            res <- try more
+            return res
+          Right (_) -> do
+            fail $ "Leading zero."
+
   where
-    zero, more :: Parser Integer
-    zero  = 0 <$ char '0'
+    leadingZeroP :: Parser String
+    leadingZeroP = do
+               out <- count 1 (char '0') >>= (\_ -> some digitChar)
+               return out
+
+    more :: Parser Integer
     more  = check =<< readMaybe . concat <$> sepBy1 (some digitChar) (char '_')
 
     check :: Maybe Integer -> Parser Integer
     check = maybe (fail "Not an integer") pure
+
+
 
 -- | Parser for hexadecimal, octal and binary numbers : included parsing
 numberP :: Parser Integer -> Parser Char -> String -> Parser Integer

--- a/src/Toml/Parser/Value.hs
+++ b/src/Toml/Parser/Value.hs
@@ -38,17 +38,15 @@ decimalP :: Parser Integer
 decimalP = do
         value <- observing $ try leadingZeroP
         case value of
-          Left (_) -> do
-            res <- try more
-            return res
-          Right (_) -> do
-            fail $ "Leading zero."
+          Left _ -> do
+            try more
+          Right _ -> 
+            fail "Leading zero."
 
   where
     leadingZeroP :: Parser String
     leadingZeroP = do
-               out <- count 1 (char '0') >>= (\_ -> some digitChar)
-               return out
+               count 1 (char '0') >>= (\_ -> some digitChar)
 
     more :: Parser Integer
     more  = check =<< readMaybe . concat <$> sepBy1 (some digitChar) (char '_')

--- a/test/Test/Toml/Parser/Integer.hs
+++ b/test/Test/Toml/Parser/Integer.hs
@@ -33,8 +33,10 @@ integerSpecs = describe "integerP" $ do
             integerFailOn "_13"
             integerFailOn "_"
         it "does not parse numbers with leading zeros" $ do
-            parseInteger "0123" 0
-            parseInteger "-023" 0
+            integerFailOn "0123"
+            integerFailOn "00123"
+            integerFailOn "-023"
+            integerFailOn "-0023"
     context "when the integer is in binary representation" $ do
         it "can parse numbers prefixed with `0b`" $ do
             parseInteger "0b1101" 13


### PR DESCRIPTION
According to the issue [#333], tomland has problem with parsing the numbers with leading zero. That problem is some sort of connected with #147 because parser should consume data and throw an error without recovering. 
That feature is now implemented thanks to the ``observing`` function. So if number has leading zero, an error will be thrown, otherwise normal ``more`` parser will be called. It took me some time to figure it out, so any advice how to make this approach better would be appreciated. 
Dario