### PR TITLE
[#368] Upgrade hashable lower to 1.3.1.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,11 @@
 `tomland` uses [PVP Versioning][1].
 The changelog is available [on GitHub][2].
 
+## 1.3.3.0 — Mar 13, 2021
+
+* Upgrade `hashable` lower bound to 1.3.1.0.
+* Sort keys in pretty printing by default.
+
 ## 🐂 1.3.2.0 — Feb 12, 2021
 
 * [#186](https://github.com/kowainik/tomland/issues/186):

--- a/src/Toml/Type/Printer.hs
+++ b/src/Toml/Type/Printer.hs
@@ -22,6 +22,7 @@ module Toml.Type.Printer
        , prettyKey
        ) where
 
+import GHC.Exts (sortWith)
 import Data.Bifunctor (first)
 import Data.Char (isAscii, ord)
 import Data.Coerce (coerce)
@@ -178,7 +179,7 @@ prettyKeyValue options i = mapOrdered (\kv -> [kvText kv]) options . HashMap.toL
     showText :: Show a => a -> Text
     showText = Text.pack . show
 
-        
+
     -- | Function encodes all non-ascii characters in TOML defined form using the isAscii function
     showTextUnicode :: Text -> Text
     showTextUnicode text = Text.pack $ show finalText
@@ -267,7 +268,7 @@ tabWith PrintOptions{..} n = Text.replicate (n * printOptionsIndent) " "
 mapOrdered :: ((Key, v) -> [t]) -> PrintOptions -> [(Key, v)] -> [t]
 mapOrdered f options = case printOptionsSorting options of
     Just sorter -> concatMap f . sortBy (sorter `on` fst)
-    Nothing     -> concatMap f
+    Nothing     -> concatMap f . sortWith fst
 
 -- Adds next part of the table name to the accumulator.
 addPrefix :: Key -> Text -> Text

--- a/stack.yaml
+++ b/stack.yaml
@@ -1,1 +1,4 @@
-resolver: nightly-2021-02-12
+resolver: lts-17.5
+
+extra-deps:
+  - hashable-1.3.1.0

--- a/test/Test/Toml/Type/Printer.hs
+++ b/test/Test/Toml/Type/Printer.hs
@@ -6,8 +6,7 @@ module Test.Toml.Type.Printer
 
 import Data.List.NonEmpty (NonEmpty ((:|)))
 import Data.Ord (comparing)
-import Test.Hspec (Arg, Expectation, Spec, SpecWith, describe, it)
-import Test.Hspec.Golden (defaultGolden)
+import Test.Hspec (Arg, Expectation, Spec, SpecWith, describe, it, shouldReturn)
 
 import Toml.Type.Edsl (empty, mkToml, table, tableArray, (=:))
 import Toml.Type.Key (Key (..), (<|))
@@ -15,7 +14,7 @@ import Toml.Type.Printer (PrintOptions (..), Lines(..), defaultOptions, prettyOp
 import Toml.Type.TOML (TOML)
 import Toml.Type.Value (Value (..))
 
-import qualified Data.Text as T
+import qualified Data.Text.IO as T
 
 
 printerSpec :: Spec
@@ -29,9 +28,8 @@ printerSpec = describe "Toml.Type.Printer: Golden tests for pretty-printing" $ d
   where
     test :: String -> PrintOptions -> SpecWith (Arg Expectation)
     test name options = it ("Golden " ++ name) $
-        defaultGolden
-            ("test/golden/" ++ name ++ ".golden")
-            (T.unpack $ prettyOptions options example)
+        T.readFile ("test/golden/" ++ name ++ ".golden")
+            `shouldReturn` prettyOptions options example
 
 example :: TOML
 example = mkToml $ do

--- a/test/golden/pretty_custom_sorted.golden
+++ b/test/golden/pretty_custom_sorted.golden
@@ -2,14 +2,13 @@ a = "a"
 b = "bb"
 c = "cccc"
 d = "ddd"
+list = ["one", "two"]
 
 [baz]
 
 [doo]
 
 [foo]
-
-list = ["one", "two"]
 
 [qux.doo]
 spam = "!"

--- a/test/golden/pretty_default.golden
+++ b/test/golden/pretty_default.golden
@@ -2,10 +2,9 @@ a = "a"
 b = "bb"
 c = "cccc"
 d = "ddd"
+list = ["one", "two"]
 
 [baz]
-
-list = ["one", "two"]
 
 [doo]
 

--- a/test/golden/pretty_indented_only.golden
+++ b/test/golden/pretty_indented_only.golden
@@ -1,15 +1,14 @@
 a = "a"
+b = "bb"
 c = "cccc"
 d = "ddd"
-b = "bb"
+list = ["one", "two"]
+
+[baz]
 
 [doo]
 
 [foo]
-
-[baz]
-
-list = ["one", "two"]
 
 [qux.doo]
     egg = "?"

--- a/test/golden/pretty_lines.golden
+++ b/test/golden/pretty_lines.golden
@@ -2,13 +2,12 @@ a = "a"
 b = "bb"
 c = "cccc"
 d = "ddd"
-
-[baz]
-
-list =
+list = 
   [ "one"
   , "two"
   ]
+
+[baz]
 
 [doo]
 

--- a/test/golden/pretty_sorted_only.golden
+++ b/test/golden/pretty_sorted_only.golden
@@ -2,10 +2,9 @@ a = "a"
 b = "bb"
 c = "cccc"
 d = "ddd"
+list = ["one", "two"]
 
 [baz]
-
-list = ["one", "two"]
 
 [doo]
 

--- a/test/golden/pretty_unformatted.golden
+++ b/test/golden/pretty_unformatted.golden
@@ -1,15 +1,14 @@
 a = "a"
+b = "bb"
 c = "cccc"
 d = "ddd"
-b = "bb"
+list = ["one", "two"]
+
+[baz]
 
 [doo]
 
 [foo]
-
-[baz]
-
-list = ["one", "two"]
 
 [qux.doo]
 egg = "?"

--- a/tomland.cabal
+++ b/tomland.cabal
@@ -1,6 +1,6 @@
 cabal-version:       2.4
 name:                tomland
-version:             1.3.2.0
+version:             1.3.3.0
 synopsis:            Bidirectional TOML serialization
 description:
     Implementation of bidirectional TOML serialization. Simple codecs look like this:
@@ -118,7 +118,7 @@ library
   build-depends:       bytestring ^>= 0.10
                      , containers >= 0.5.7 && < 0.7
                      , deepseq ^>= 1.4
-                     , hashable >= 1.2 && < 1.4
+                     , hashable >= 1.3.1.0 && < 1.4
                      , megaparsec >= 7.0.5 && < 9.1
                      , mtl ^>= 2.2
                      , parser-combinators >= 1.1.0 && < 1.4
@@ -214,7 +214,6 @@ test-suite tomland-test
                      , hedgehog ^>= 1.0.1
                      , hspec ^>= 2.7.1
                      , hspec-hedgehog ^>= 0.0.1
-                     , hspec-golden ^>= 0.1.0
                      , hspec-megaparsec >= 2.0.0 && < 2.3.0
                      , megaparsec
                      , directory ^>= 1.3


### PR DESCRIPTION
Resolves #368

Also remove `hspec-golden` from dependencies, as it seems to be causing issues with tests after the update.