### PR TITLE
Add flags that control building the executables

### DIFF
--- a/cabal.project
+++ b/cabal.project
@@ -1,0 +1,4 @@
+packages: .
+
+package tomland
+  flags: +build-readme +build-play-tomland

--- a/stack.yaml
+++ b/stack.yaml
@@ -2,3 +2,8 @@ resolver: lts-17.5
 
 extra-deps:
   - hashable-1.3.1.0
+
+flags:
+  tomland:
+    build-readme: true
+    build-play-tomland: true

--- a/tomland.cabal
+++ b/tomland.cabal
@@ -44,6 +44,16 @@ source-repository head
   type:                git
   location:            https://github.com/kowainik/tomland.git
 
+flag build-readme
+  description:         Build README generator.
+  default:             False
+  manual:              True
+
+flag build-play-tomland
+  description:         Build play-tomland executable.
+  default:             False
+  manual:              True
+
 common common-options
   build-depends:       base >= 4.11 && < 4.16
 
@@ -132,7 +142,7 @@ library
 executable readme
   import:              common-options
   -- doesn't work on windows for unknown reasons
-  if os(windows)
+  if !flag(build-readme) || os(windows)
     buildable: False
   main-is:             README.lhs
   build-depends:       tomland
@@ -145,7 +155,7 @@ executable readme
 executable play-tomland
   import:              common-options
   -- We are using DerivingVia that works only with > 8.6
-  if impl(ghc < 8.6)
+  if !flag(build-play-tomland) || impl(ghc < 8.6)
     buildable: False
   main-is:             Main.hs
   build-depends:       tomland


### PR DESCRIPTION
The `readme` and `play-tomland` executables have very limited usefulness for usual
package users. Therefore it is better to disable them by default in
order to conserve resources.

Additionally, because `build-tool-depends` as used in the `readme`
executable are currently unsupported by Hackage's docs builder,
automated docs builds didn't work for `tomland` and any packages that
depend on it.

Context:
https://github.com/haskell/hackage-server/issues/988#issuecomment-956508617