### PR TITLE
Return 'TomlState ()' in codecWrite

### DIFF
--- a/src/Toml/Codec/Combinator/Common.hs
+++ b/src/Toml/Codec/Combinator/Common.hs
@@ -60,10 +60,10 @@ match BiMap{..} key = Codec input output
         Nothing     -> Failure [KeyNotFound key]
         Just anyVal -> whenLeftBiMapError key (backward anyVal) pure
 
-    output :: a -> TomlState a
+    output :: a -> TomlState ()
     output a = do
         anyVal <- eitherToTomlState $ forward a
-        a <$ modify (insertKeyAnyVal key anyVal)
+        modify (insertKeyAnyVal key anyVal)
 
 {- | Throw error on 'Left', or perform a given action with 'Right'.
 

--- a/src/Toml/Codec/Combinator/Map.hs
+++ b/src/Toml/Codec/Combinator/Map.hs
@@ -347,7 +347,7 @@ internalMap emptyMap toListMap fromListMap keyCodec valCodec key = Codec input o
             v <- codecRead valCodec toml
             pure (k, v)
 
-    output :: map -> TomlState map
+    output :: map -> TomlState ()
     output dict = do
         let tomls = fmap
                 (\(k, v) -> execTomlCodec keyCodec k <> execTomlCodec valCodec v)
@@ -363,7 +363,7 @@ internalMap emptyMap toListMap fromListMap keyCodec valCodec key = Codec input o
                 Just (t :| ts) ->
                     insertTableArrays key $ t :| (ts ++ tomls)
 
-        dict <$ modify updateAction
+        modify updateAction
 
 internalTableMap
     :: forall map k v
@@ -391,12 +391,12 @@ internalTableMap emptyMap toListMap fromListMap keyBiMap valCodec tableName =
                 whenLeftBiMapError key (forward keyBiMap key) $ \k ->
                     (k,) <$> codecRead (valCodec key) toml
 
-    output :: map -> TomlState map
+    output :: map -> TomlState ()
     output m = do
         mTable <- gets $ Prefix.lookup tableName . tomlTables
         let toml = fromMaybe mempty mTable
         let (_, newToml) = unTomlState updateMapTable toml
-        m <$ modify (insertTable tableName newToml)
+        modify (insertTable tableName newToml)
       where
         updateMapTable :: TomlState ()
         updateMapTable = forM_ (toListMap m) $ \(k, v) -> case backward keyBiMap k of

--- a/src/Toml/Codec/Combinator/Table.hs
+++ b/src/Toml/Codec/Combinator/Table.hs
@@ -87,9 +87,9 @@ table codec key = Codec input output
         Nothing   -> Failure [TableNotFound key]
         Just toml -> handleTableErrors codec key toml
 
-    output :: a -> TomlState a
+    output :: a -> TomlState ()
     output a = do
         mTable <- gets $ Prefix.lookup key . tomlTables
         let toml = fromMaybe mempty mTable
         let (_, newToml) = unTomlState (codecWrite codec a) toml
-        a <$ modify (insertTable key newToml)
+        modify (insertTable key newToml)

--- a/src/Toml/Codec/Di.hs
+++ b/src/Toml/Codec/Di.hs
@@ -21,6 +21,7 @@ module Toml.Codec.Di
 
 import Control.Applicative (Alternative (..))
 import Data.Coerce (Coercible, coerce)
+import Data.Foldable (traverse_)
 
 import Toml.Codec.Types (Codec (..), TomlCodec, (<!>))
 
@@ -78,7 +79,7 @@ dimap
     -> TomlCodec b  -- ^ Target 'Codec' object
 dimap f g codec = Codec
     { codecRead  = fmap g . codecRead codec
-    , codecWrite = fmap g . codecWrite codec . f
+    , codecWrite = codecWrite codec . f
     }
 {-# INLINE dimap #-}
 
@@ -108,7 +109,7 @@ dioptional
     -> TomlCodec (Maybe a)
 dioptional Codec{..} = Codec
     { codecRead  = fmap Just . codecRead <!> \_ -> pure Nothing
-    , codecWrite = traverse codecWrite
+    , codecWrite = traverse_ codecWrite
     }
 {-# INLINE dioptional #-}
 
@@ -184,7 +185,7 @@ dimatch match ctor codec = Codec
     { codecRead = fmap ctor . codecRead codec
     , codecWrite = \c -> case match c of
         Nothing -> empty
-        Just d  -> ctor <$> codecWrite codec d
+        Just d  -> codecWrite codec d
     }
 {-# INLINE dimatch #-}
 

--- a/src/Toml/Codec/Types.hs
+++ b/src/Toml/Codec/Types.hs
@@ -49,22 +49,21 @@ import Toml.Type (TOML (..))
 type TomlEnv a = TOML -> Validation [TomlDecodeError] a
 
 
-{- | Specialied 'Codec' type alias for bidirectional TOML serialization. Keeps
+{- | Specialized 'Codec' type alias for bidirectional TOML serialization. Keeps
 'TOML' object as both environment and state.
 
 @since 0.5.0
 -}
 type TomlCodec a = Codec a a
 
-{- | Monad for bidirectional conversion. Contains pair of functions:
+{- | Monad for bidirectional conversion. Contains a pair of functions:
 
-1. How to read value of type @o@ (out) from immutable environment context
+1. How to read a value of type @o@ (out) from an immutable environment context
 ('TomlEnv')?
-2. How to store a value of type @i@ (in) in stateful context ('TomlState') and
-return a value of type @o@?
+2. How to store a value of type @i@ (in) in a stateful context ('TomlState')?
 
-This approach with the bunch of utility functions allows to
-have single description for from/to @TOML@ conversion.
+This approach, along with a bunch of utility functions, allows us to
+have a single description for @TOML@ serialization + deserialization.
 
 In practice this type will always be used in the following way:
 
@@ -72,9 +71,11 @@ In practice this type will always be used in the following way:
 type 'TomlCodec' a = 'Codec' a a
 @
 
-Type parameter @i@ if fictional. Here some trick is used. This trick is
-implemented in the [codec](http://hackage.haskell.org/package/codec) package and
-described in more details in related blog post:
+However, we need to represent @i@ separately from @o@ in order to implement
+instances like 'Alternative', which requires the type parameter to be covariant,
+but @i@ is contravariant. This trick is inspired by the
+[codec](http://hackage.haskell.org/package/codec) package and
+described in more details in this blog post:
 <https://blog.poisson.chat/posts/2016-10-12-bidirectional-serialization.html>.
 
 @since 0.0.0
@@ -133,15 +134,14 @@ f <!> g = \a -> f a <|> g a
 {-# INLINE (<!>) #-}
 
 {- | Mutable context for TOML conversion.
-We are introducing our own implemetation of state with 'MonadState' instance due
-to some limitation in the design connected to the usage of State.
+We are introducing our own implementation of state with 'MonadState' instance due
+to some limitations in the design connected to the usage of State.
 
 This newtype is equivalent to the following transformer:
 
 @
 MaybeT (State TOML)
 @
-
 
 @since 1.3.0.0
 -}


### PR DESCRIPTION
`Codec` no longer has a `Monad` instance, as of 1.3.0.0, so there's no longer any need to keep returning `TomlState o`. As a newcomer, it's difficult to understand the type of `Codec` (what is the result `o` used for?), and this would help a lot in that direction.