### PR TITLE
Fix typing issue with Gen.element

### DIFF
--- a/test/Test/Toml/Gen.hs
+++ b/test/Test/Toml/Gen.hs
@@ -114,7 +114,7 @@ genPiece = Piece <$> Gen.choice [bare, quoted]
     bare = liftA2 Text.cons Gen.alpha $ Gen.text (Range.constant 1 10) alphadashes
 
     alphadashes :: Gen Char
-    alphadashes = Gen.choice [Gen.alphaNum, Gen.element "_-"]
+    alphadashes = Gen.choice [Gen.alphaNum, Gen.element ("_-" :: String)]
 
     quoted :: Gen Text
     quoted = genNotEscape $ Gen.choice


### PR DESCRIPTION
I get the following error message, which is quite similar to https://github.com/aisamanra/config-ini/issues/44:

```
[ 3 of 39] Compiling Test.Toml.Gen

test/Test/Toml/Gen.hs:116:57: error:
    • Ambiguous type variable ‘f0’ arising from the literal ‘"_-"’
      prevents the constraint ‘(Data.String.IsString
                                  (f0 Char))’ from being solved.
      Probable fix: use a type annotation to specify what ‘f0’ should be.
      These potential instances exist:
        instance (a ~ Char) => Data.String.IsString [a]
          -- Defined in ‘Data.String’
        ...plus 8 instances involving out-of-scope types
        (use -fprint-potential-instances to see them all)
    • In the first argument of ‘Gen.element’, namely ‘"_-"’
      In the expression: Gen.element "_-"
      In the first argument of ‘Gen.choice’, namely
        ‘[Gen.alphaNum, Gen.element "_-"]’
    |
116 |     alphadashes = Gen.choice [Gen.alphaNum, Gen.element "_-"]
    |                                                         ^^^^

test/Test/Toml/Gen.hs:116:45: error:
    • Ambiguous type variable ‘f0’ arising from a use of ‘Gen.element’
      prevents the constraint ‘(Foldable f0)’ from being solved.
      Probable fix: use a type annotation to specify what ‘f0’ should be.
      These potential instances exist:
        instance Foldable (Either a) -- Defined in ‘Data.Foldable’
        instance Foldable NonEmpty -- Defined in ‘Data.Foldable’
        instance Foldable (Map k) -- Defined in ‘Data.Map.Internal’
        ...plus 7 others
        ...plus 66 instances involving out-of-scope types
        (use -fprint-potential-instances to see them all)
    • In the expression: Gen.element "_-"
      In the first argument of ‘Gen.choice’, namely
        ‘[Gen.alphaNum, Gen.element "_-"]’
      In the expression: Gen.choice [Gen.alphaNum, Gen.element "_-"]
    |
116 |     alphadashes = Gen.choice [Gen.alphaNum, Gen.element "_-"]
```

The fix is analogous to the one in the referenced issue. This solves the error completely