### PR TITLE
Bump bytestring to < 0.13

### DIFF
--- a/tomland.cabal
+++ b/tomland.cabal
@@ -131,7 +131,7 @@ library
                            Toml.Type.UValue
                            Toml.Type.Value
 
-  build-depends:       bytestring >= 0.10 && < 0.12
+  build-depends:       bytestring >= 0.10 && < 0.13
                      , containers >= 0.5.7 && < 0.7
                      , deepseq >= 1.4 && < 1.6
                      , hashable >= 1.3.1.0 && < 1.5


### PR DESCRIPTION
This matches the revision -r1 already made at

https://hackage.haskell.org/package/tomland-1.3.3.2/revisions/