### PR TITLE
Support 9.14

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -33,6 +33,7 @@ jobs:
           - "9.8.1"
           - "9.10.1"
           - "9.12.1"
+          - "9.14.1"
         exclude:
           - os: macOS-latest
             ghc: 9.2.7

--- a/cabal.project
+++ b/cabal.project
@@ -2,3 +2,5 @@ packages: .
 
 package tomland
   flags: +build-readme +build-play-tomland
+
+allow-newer: boring:base

--- a/tomland.cabal
+++ b/tomland.cabal
@@ -60,7 +60,7 @@ flag build-play-tomland
   manual:              True
 
 common common-options
-  build-depends:       base >= 4.11 && < 4.22
+  build-depends:       base >= 4.11 && < 4.23
 
   ghc-options:         -Wall
                        -Wcompat


### PR DESCRIPTION
Use cabal.project to relax boring's bounds.  This will allow CI to run, but not leak into released sdists.