### PR TITLE
Bump time

### DIFF
--- a/tomland.cabal
+++ b/tomland.cabal
@@ -142,7 +142,7 @@ library
                      , mtl >= 2.2 && < 2.4
                      , parser-combinators >= 1.1.0 && < 1.4
                      , text >= 1.2 && < 2.2
-                     , time >= 1.8 && < 1.16
+                     , time >= 1.8 && < 1.17
                      , unordered-containers ^>= 0.2.7
                      , validation-selective >= 0.1.0 && < 0.3
 


### PR DESCRIPTION
:warning: Should not merge this until we can see that `time-1.17` is actually used in the build. Seems like some of our dependencies are not compatible with `time-1.17`.